### PR TITLE
USMC 42/44 de-randomization

### DIFF
--- a/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
@@ -76,7 +76,7 @@
 
 //#include "loadoutsVeh\Russian\vehGearRUS.sqf"
 
-#include "loadoutsVeh\German\vehGearWHR.sqf"
+//#include "loadoutsVeh\German\vehGearWHR.sqf"
 
 //============ Loadouts ============
 
@@ -86,8 +86,8 @@
 
     //=== British ===
     //Army
-#include "loadouts\British\gearUK40.sqf"
-#include "loadouts\British\gearUK44.sqf"
+//#include "loadouts\British\gearUK40.sqf"
+//#include "loadouts\British\gearUK44.sqf"
 
     //=== German ===
     //Fallschirmjäger

--- a/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
@@ -124,5 +124,5 @@
 //#include "loadouts\US\gearUSAB44.sqf"
 
     //Marine Corps
-#include "loadouts\US\gearUSMC42.sqf"
-#include "loadouts\US\gearUSMC44.sqf"
+//#include "loadouts\US\gearUSMC42.sqf"
+//#include "loadouts\US\gearUSMC44.sqf"

--- a/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/gearLoadouts.sqf
@@ -76,7 +76,7 @@
 
 //#include "loadoutsVeh\Russian\vehGearRUS.sqf"
 
-//#include "loadoutsVeh\German\vehGearWHR.sqf"
+#include "loadoutsVeh\German\vehGearWHR.sqf"
 
 //============ Loadouts ============
 
@@ -124,5 +124,5 @@
 //#include "loadouts\US\gearUSAB44.sqf"
 
     //Marine Corps
-//#include "loadouts\US\gearUSMC42.sqf"
-//#include "loadouts\US\gearUSMC44.sqf"
+#include "loadouts\US\gearUSMC42.sqf"
+#include "loadouts\US\gearUSMC44.sqf"

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
@@ -38,16 +38,8 @@
 #define USMC42_Weapon_Leader \
                 [USMC_Vest_M1T] call Olsen_FW_FNC_AddItem; \
                 [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
-                [US_Weap_M1928A1] call Olsen_FW_FNC_AddItem; \
+                [US_Weap_M1T] call Olsen_FW_FNC_AddItem; \
                 [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem;
-
-// For Automatic Riflemen
-#define USMC42_Weapon_AR \
-        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
-        [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
-        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
 
 // For Riflemen
 #define USMC42_Weapon_Rifle \
@@ -66,11 +58,26 @@
             ],[30] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
 
-// For Machinegunner
+// For Radiomen, Messengers, Medics and Tank Crew
+#define USMC42_Weapon_Rifle_Light \
+        [US_Mag_M1C,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1C] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1C,5,"vest"] call Olsen_FW_FNC_AddItem;
+
+// For Automatic Riflemen
+#define USMC42_Weapon_AR \
+        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
+        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Machinegunners
         [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
         [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
         [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
 
+// Colt M1911 Pistol
 #define USMC42_Weapon_Secondary \
         [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1911] call Olsen_FW_FNC_AddItem; \
@@ -132,6 +139,7 @@
     USMC42_Mess = ["USMC42_Mess", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_e_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -140,7 +148,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        USMC42_Weapon_Rifle;
+        USMC42_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -256,6 +264,7 @@
     USMC42_MedS = ["USMC42_MedS", {
         params ["_unit"];
  
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_e_r] call Olsen_FW_FNC_AddItemRandom;
@@ -266,7 +275,7 @@
         GEN_MedicS_Equipment_Set;
 
         //Primary Weapon
-        USMC42_Weapon_Rifle;
+        USMC42_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
@@ -301,6 +310,7 @@
     USMC42_MGTL = ["USMC42_MGTL", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_e_r] call Olsen_FW_FNC_AddItemRandom;
@@ -348,6 +358,7 @@
     USMC42_BzkaTL = ["USMC42_BzkaTL", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -370,6 +381,7 @@
     USMC42_BzkaG = ["USMC42_BzkaG", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -393,6 +405,7 @@
     USMC42_VCom = ["USMC42_VCom", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_SGT] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_VCrew] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
@@ -402,6 +415,9 @@
         GEN_Default_Equipment_Set;
         GEN_Leader_Equipment_Set;
 
+        //Primary Weapon
+        USMC42_Weapon_Rifle_Light;
+
         //Secondary Weapon
         USMC42_Weapon_Secondary;
     }];
@@ -410,6 +426,7 @@
     USMC42_VCrew = ["USMC42_VCrew", {
         params ["_unit"];
 
+        [US_Vest_Pistol] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_VCrew] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
@@ -36,88 +36,12 @@
 
 // For Platoon Commander, Squad Leader
 #define USMC42_Weapon_Leader \
-        [ \
-            [/*M1928 Thompson*/ \
-                [USMC_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928], \
-                [US_Mag_M1T_20,5,"vest"] \
-            ],[9], \
-            [/*M1928A1 Thompson*/ \
-                [USMC_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928A1], \
-                [US_Mag_M1T_20,5,"vest"] \
-            ],[46], \
-            [/*M1 Thompson*/ \
-                [USMC_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1T], \
-                [US_Mag_M1T_20,4,"vest"], \
-                [US_Mag_M1T_30,1,"vest"] \
-            ],[9], \
-            [/*M50 Reising*/ \
-                [USMC_Vest_M1T], \
-                [US_Mag_M50_20,1], \
-                [US_Weap_M50], \
-                [US_Mag_M50_20,5,"vest"] \
-            ],[15], \
-            [/*M55 Reising*/ \
-                [USMC_Vest_M1T], \
-                [US_Mag_M50_20,1], \
-                [US_Weap_M55], \
-                [US_Mag_M50_20,5,"vest"] \
-            ],[1], \
-            [/*M1 Carbine*/ \
-                [USMC_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[20] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+                [USMC_Vest_M1T] call Olsen_FW_FNC_AddItem; \
+                [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
+                [US_Weap_M1928A1] call Olsen_FW_FNC_AddItem; \
+                [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem;
 
-#define USMC42_Weapon_Rifle_Light \
-    if (vest _unit isEqualTo "") then { \
-        [ \
-            [/*M1903A1*/ \
-                [USMC_Vest_M1G], \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[76], \
-            [/*M1903A3*/ \
-                [USMC_Vest_M1G], \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[14], \
-            [/*M1 Carbine*/ \
-                [USMC_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[10] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent; \
-    } else { \
-        [ \
-            [/*M1903A1*/ \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[76], \
-            [/*M1903A3*/ \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[14], \
-            [/*M1 Carbine*/ \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[10] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent; \
-    };
-
+// For Automatic Riflemen
 #define USMC42_Weapon_AR \
         [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
         [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
@@ -125,47 +49,27 @@
         [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
         [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
 
+// For Riflemen
 #define USMC42_Weapon_Rifle \
-    if (vest _unit isEqualTo "") then { \
         [ \
             [/*M1903A1*/ \
                 [USMC_Vest_M1G], \
                 [US_Mag_M1903,1], \
                 [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[76], \
-            [/*M1903A3*/ \
-                [USMC_Vest_M1G], \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[14], \
+                [US_Mag_M1903,12,"vest"] \
+            ],[70], \
             [/*M1 Carbine*/ \
                 [USMC_Vest_M1C], \
                 [US_Mag_M1C,1], \
                 [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[10] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent; \
-    } else { \
-        [ \
-            [/*M1903A1*/ \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[76], \
-            [/*M1903A3*/ \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[14], \
-            [/*M1 Carbine*/ \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[10] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent; \
-    };
+                [US_Mag_M1C,5,"vest"] \
+            ],[30] \
+        ] call Olsen_FW_FNC_AddItemRandomPercent;
+
+// For Machinegunner
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
+        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
 
 #define USMC42_Weapon_Secondary \
         [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
@@ -351,15 +255,8 @@
     //Assistant Medic
     USMC42_MedS = ["USMC42_MedS", {
         params ["_unit"];
-
-        [
-            [
-                [USMC_Uni_PFC]
-            ],[90],
-            [
-                [USMC_Uni_PVT]
-            ],[10]
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+ 
+        [USMC_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_e_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -374,21 +271,14 @@
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,2,"backpack"] call Olsen_FW_FNC_AddItem;
+        [US_Mag_BAR_Mixed_Ball,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Rifleman
     USMC42_Rif = ["USMC42_Rif", {
         params ["_unit"];
 
-        [
-            [
-                [USMC_Uni_PFC]
-            ],[90],
-            [
-                [USMC_Uni_PVT]
-            ],[10]
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+        [USMC_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_e_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -402,7 +292,7 @@
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,2,"backpack"] call Olsen_FW_FNC_AddItem;
+        [US_Mag_BAR_Mixed_Ball,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
 //Machine Gun Team
@@ -520,17 +410,7 @@
     USMC42_VCrew = ["USMC42_VCrew", {
         params ["_unit"];
 
-        [
-            [
-                [USMC_Uni_CPL]
-            ],[40],
-            [
-                [USMC_Uni_PFC]
-            ],[55],
-            [
-                [USMC_Uni_PVT]
-            ],[5]
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+        [USMC_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [USMC_BP_M1928] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_VCrew] call Olsen_FW_FNC_AddItem;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
@@ -11,7 +11,7 @@
 [this, USMC44_PSGT] call Olsen_FW_FNC_GearScript;         Platoon Sergeant/Platoon Guide
 [this, USMC44_PRTO] call Olsen_FW_FNC_GearScript;         Platoon Radio Operator
 [this, USMC44_Mess] call Olsen_FW_FNC_GearScript;         Messenger
-[this, USMC44_MedP] call Olsen_FW_FNC_GearScript;          Medic
+[this, USMC44_MedP] call Olsen_FW_FNC_GearScript;         Medic
 
     //Squad
 [this, USMC44_SL] call Olsen_FW_FNC_GearScript;           Squad Leader
@@ -38,38 +38,47 @@
 
 // For Platoon Commander, Squad Leader
 #define USMC44_Weapon_Leader \
-                [USMC_Vest_M1T] call Olsen_FW_FNC_AddItem; \
-                [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
-                [US_Weap_M1928A1] call Olsen_FW_FNC_AddItem; \
-                [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem;
+        [USMC_Vest_M1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_30,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1A1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_30,5,"vest"] call Olsen_FW_FNC_AddItem;
 
 // For Riflemen
 #define USMC44_Weapon_Rifle \
+        [USMC_Vest_M1G] call Olsen_FW_FNC_AddItem; \
         [US_Mag_M1G,1] call Olsen_FW_FNC_AddItem; \
         [US_Acc_M1_Bayo,1,"uniform"] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1G] call Olsen_FW_FNC_AddItem; \
         [US_Mag_M1G,10,"backpack"] call Olsen_FW_FNC_AddItem;
 
-// For Radiomen and Messengers
+// For Radiomen, Messengers and Medics
 #define USMC44_Weapon_Rifle_Light \
-                [US_Mag_M1C,1], call Olsen_FW_FNC_AddItem; \
-                [US_Weap_M1C], call Olsen_FW_FNC_AddItem; \
-                [US_Mag_M1C,5,"vest"] call Olsen_FW_FNC_AddItem;
+        [US_Mag_M1C,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1C] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1C,5,"vest"] call Olsen_FW_FNC_AddItem;
 
 // For Automatic Riflemen
-#define USMC42_Weapon_AR \
+#define USMC44_Weapon_AR \
         [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
         [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
         [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
         [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
         [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
 
-// For Machinegunner
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+// For Machinegunners
+#define USMC44_Weapon_MG \
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1919_250_Mixed_Ball,3,"backpack"] call Olsen_FW_FNC_AddItem;
 
-#define USMC42_Weapon_Secondary \
+// For Tank Crew
+#define USMC44_Weapon_M3GG \
+        [US_Mag_M3GG,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M3GG] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M3GG,3,"vest"] call Olsen_FW_FNC_AddItem;
+
+// Colt M1911 Pistol
+#define USMC44_Weapon_Secondary \
         [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1911] call Olsen_FW_FNC_AddItem; \
         [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
@@ -95,7 +104,7 @@
         USMC44_Weapon_Leader;
 
         //Secondary Weapon
-        USMC42_Weapon_Secondary;
+        USMC44_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -119,7 +128,7 @@
         USMC44_Weapon_Leader;
 
         //Secondary Weapon
-        USMC42_Weapon_Secondary;
+        USMC44_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -130,6 +139,7 @@
     USMC44_PRTO = ["USMC44_PRTO", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [USMC_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [USMC_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -151,6 +161,7 @@
     USMC44_Mess = ["USMC44_Mess", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -244,7 +255,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        USMC42_Weapon_AR;
+        USMC44_Weapon_AR;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -352,12 +363,10 @@
         GEN_Default_Equipment_Set;
 
         //Secondary Weapon
-        USMC42_Weapon_Secondary;
+        USMC44_Weapon_Secondary;
 
         //Primary Weapon
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+        USMC44_Weapon_MG;
     }];
 
 //Bazooka Team
@@ -411,6 +420,7 @@
     USMC44_VCom = ["USMC44_VCom", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_SGT] call Olsen_FW_FNC_AddItem;
         [USMC_Helm_VCrew] call Olsen_FW_FNC_AddItem;
         [USMC_BP_r] call Olsen_FW_FNC_AddItemRandom;
@@ -421,16 +431,17 @@
         GEN_Leader_Equipment_Set;
 
         //Primary Weapon
-        USMC44_Weapon_Leader;
+        USMC44_Weapon_M3GG;
 
         //Secondary Weapon
-        USMC42_Weapon_Secondary;
+        USMC44_Weapon_Secondary;
     }];
 
     //Tank Crew
     USMC44_VCrew = ["USMC44_VCrew", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USMC_Uni_PVT] call Olsen_FW_FNC_AddItemRandom;
         [USMC_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [USMC_Helm_VCrew] call Olsen_FW_FNC_AddItem;
@@ -440,7 +451,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        USMC44_Weapon_Rifle_Light;
+        USMC44_Weapon_M3GG;
 
         //Extra
         [GEN_Toolkit] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
@@ -38,39 +38,41 @@
 
 // For Platoon Commander, Squad Leader
 #define USMC44_Weapon_Leader \
-        [ \
-            [ \
-                [US_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,5,"vest"] \
-            ],[33], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M3GG,1], \
-                [US_Weap_M3GG], \
-                [US_Mag_M3GG,5,"vest"] \
-            ],[33], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_30,1], \
-                [US_Weap_M1A1T], \
-                [US_Mag_M1T_30,5,"vest"] \
-            ],[34] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+                [USMC_Vest_M1T] call Olsen_FW_FNC_AddItem; \
+                [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
+                [US_Weap_M1928A1] call Olsen_FW_FNC_AddItem; \
+                [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem;
 
-// For light riflemen
-#define USMC44_Weapon_Rifle_Light \
-        [US_Mag_M1C,1] call Olsen_FW_FNC_AddItem; \
-        [US_Weap_M1C] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_M1C,10,"backpack"] call Olsen_FW_FNC_AddItem; \
-
-// For riflemen
+// For Riflemen
 #define USMC44_Weapon_Rifle \
         [US_Mag_M1G,1] call Olsen_FW_FNC_AddItem; \
         [US_Acc_M1_Bayo,1,"uniform"] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1G] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_M1G,10,"backpack"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1G,10,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Radiomen and Messengers
+#define USMC44_Weapon_Rifle_Light \
+                [US_Mag_M1C,1], call Olsen_FW_FNC_AddItem; \
+                [US_Weap_M1C], call Olsen_FW_FNC_AddItem; \
+                [US_Mag_M1C,5,"vest"] call Olsen_FW_FNC_AddItem;
+
+// For Automatic Riflemen
+#define USMC42_Weapon_AR \
+        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
+        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Machinegunner
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
+        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+
+#define USMC42_Weapon_Secondary \
+        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1911] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
 
 //======================== Loadouts ========================
 
@@ -93,9 +95,7 @@
         USMC44_Weapon_Leader;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -119,9 +119,7 @@
         USMC44_Weapon_Leader;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -246,11 +244,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_BAR] call Olsen_FW_FNC_AddItem;
-        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_AR;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -296,7 +290,7 @@
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,7,"backpack"] call Olsen_FW_FNC_AddItem;
+        [US_Mag_BAR_Mixed_Ball,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Rifleman
@@ -317,7 +311,7 @@
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,7,"backpack"] call Olsen_FW_FNC_AddItem;
+        [US_Mag_BAR_Mixed_Ball,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
 //Machine Gun Team
@@ -358,9 +352,7 @@
         GEN_Default_Equipment_Set;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_Secondary;
 
         //Primary Weapon
         [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
@@ -432,9 +424,7 @@
         USMC44_Weapon_Leader;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_Secondary;
     }];
 
     //Tank Crew


### PR DESCRIPTION
Derandomized Weapon_Leader and Weapon_Rifle in USMC 42 and 44.

Added definitions for M1911 sidearm and M1919 MG.

Removed uniform randomization on Rifleman, Assistant Medic and Tank Crew. Now spawn with set uniform type (instead of a chance between PVT, CPL or PFC)

Closes #13 