### PR TITLE
Typo in Rus44 Loadout

### DIFF
--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus44.sqf
@@ -292,7 +292,7 @@
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Primary Weapon & Vest
-        R41_Weapon_Rifleman;
+        R44_Weapon_Rifleman;
 
         //Assigned Items
         GEN_Default_Equipment_Set;


### PR DESCRIPTION
Assistant medics were pulling the R41 rifleman weapon instead of R44.