### PR TITLE
US42/44 De-randomisation

### DIFF
--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
@@ -73,12 +73,12 @@
                 [US_Acc_M1_Bayo,1,"uniform"], \
                 [US_Weap_M1G], \
                 [US_Mag_M1G,10,"vest"] \
-            ],[60], \
+            ],[70], \
             [ \
                 [US_Mag_M1903,1], \
                 [US_Weap_M1903A1], \
                 [US_Mag_M1903,12,"vest"] \
-            ],[40] \
+            ],[30] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
 
 // For Tank Commander

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
@@ -21,8 +21,11 @@
 [this, US42_Rif] call Olsen_FW_FNC_GearScript;        Rifleman
 
     //Weapons Teams
-[this, USMC42_BzkaTL] call Olsen_FW_FNC_GearScript;   Bazooka Team Leader
-[this, USMC42_BzkaG] call Olsen_FW_FNC_GearScript;    Bazooka Gunner
+[this, US42_MGTL] call Olsen_FW_FNC_GearScript;       Machine Gun Team Leader
+[this, US42_MG] call Olsen_FW_FNC_GearScript;         Machine Gunner
+
+[this, US42_BzkaTL] call Olsen_FW_FNC_GearScript;     Bazooka Team Leader
+[this, US42_BzkaG] call Olsen_FW_FNC_GearScript;      Bazooka Gunner
 
     //Tank Crew
 [this, US42_VCom] call Olsen_FW_FNC_GearScript;       Tank Commander
@@ -39,46 +42,30 @@
                 [US_Mag_M1C,1], \
                 [US_Weap_M1C], \
                 [US_Mag_M1C,5,"vest"] \
-            ],[25], \
+            ],[30], \
             [ \
                 [US_Vest_M1T], \
-                [US_Mag_M1T_30,1], \
+                [US_Mag_M1T_20,1], \
                 [US_Weap_M1T], \
-                [US_Mag_M1T_30,5,"vest"] \
-            ],[75] \
+                [US_Mag_M1T_20,5,"vest"] \
+            ],[70] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
 
-// For light riflemen
+// For Radiomen, Messengers and Medics
 #define US42_Weapon_Rifle_Light \
-        [ \
-            [ \
-                [US_Vest_M1G], \
-                [US_Mag_M1G,1], \
-                [US_Acc_M1_Bayo,1,"uniform"], \
-                [US_Weap_M1G], \
-                [US_Mag_M1G,10,"vest"] \
-            ],[48], \
-            [ \
-                [US_Vest_M1G], \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[27], \
-            [ \
-                [US_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[20], \
-            [ \
-                [US_Vest_M1G], \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[5] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+        [US_Mag_M1C,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1C] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1C,5,"backpack"] call Olsen_FW_FNC_AddItem;
 
-// For riflemen
+// For Automatic Riflemen
+#define US42_Weapon_AR \
+        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
+        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Riflemen
 #define US42_Weapon_Rifle \
         [ \
             [ \
@@ -90,90 +77,28 @@
             [ \
                 [US_Mag_M1903,1], \
                 [US_Weap_M1903A1], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[34], \
-            [ \
-                [US_Mag_M1903,1], \
-                [US_Weap_M1903A3], \
-                [US_Mag_M1903,20,"vest"] \
-            ],[6] \
+                [US_Mag_M1903,12,"vest"] \
+            ],[40] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
 
 // For Tank Commander
 #define US42_Weapon_VCom \
-        [ \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928A1], \
-                [US_Mag_M1T_20,5,"vest"] \
-            ],[70], \
-            [ \
-                [US_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"] \
-            ],[10], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_30,1], \
-                [US_Weap_M1T], \
-                [US_Mag_M1T_30,5,"vest"] \
-            ],[10], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928], \
-                [US_Mag_M1T_20,5,"vest"] \
-            ],[10] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+        [US_Vest_M1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem; \
 
-// For Tank Crew
-#define US42_Weapon_VCrew \
-        [ \
-            [ \
-                [US_Vest_Pistol], \
-                [US_Mag_M1911,1], \
-                [US_Weap_M1911], \
-                [US_Mag_M1911,3,"uniform"] \
-            ],[90], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928A1], \
-                [US_Mag_M1T_20,5,"vest"], \
-                [US_Mag_M1911,1], \
-                [US_Weap_M1911], \
-                [US_Mag_M1911,3,"uniform"] \
-            ],[7], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_30,1], \
-                [US_Weap_M1T], \
-                [US_Mag_M1T_30,5,"vest"], \
-                [US_Mag_M1911,1], \
-                [US_Weap_M1911], \
-                [US_Mag_M1911,3,"uniform"] \
-            ],[1], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M1T_20,1], \
-                [US_Weap_M1928], \
-                [US_Mag_M1T_20,5,"vest"], \
-                [US_Mag_M1911,1], \
-                [US_Weap_M1911], \
-                [US_Mag_M1911,3,"uniform"] \
-            ],[1], \
-            [ \
-                [US_Vest_M1C], \
-                [US_Mag_M1C,1], \
-                [US_Weap_M1C], \
-                [US_Mag_M1C,4,"vest"], \
-                [US_Mag_M1911,1], \
-                [US_Weap_M1911], \
-                [US_Mag_M1911,3,"uniform"] \
-            ],[1] \
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+// For Machinegunners
+#define US42_Weapon_MG \
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+
+// Colt M1911 Pistol
+#define US42_Weapon_Secondary \
+        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1911] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem; \
 
 //======================== Loadouts ========================
 
@@ -195,9 +120,7 @@
         US42_Weapon_Leader;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -218,12 +141,10 @@
         GEN_Leader_Equipment_Set;
 
         //Primary Weapon
-        US42_Weapon_Rifle_Light;
+        US42_Weapon_Rifle;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -234,6 +155,7 @@
     US42_Mess = ["US42_Mess", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -263,7 +185,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        US42_Weapon_Rifle;
+        US42_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -327,11 +249,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_BAR] call Olsen_FW_FNC_AddItem;
-        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_AR;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -349,7 +267,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        [GEN_Bino] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         US42_Weapon_Rifle;
@@ -374,7 +291,7 @@
         GEN_MedicS_Equipment_Set;
 
         //Primary Weapon
-        US42_Weapon_Rifle;
+        US42_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
@@ -444,14 +361,10 @@
         GEN_Default_Equipment_Set;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,2,"uniform"] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_Secondary;
 
         //Primary Weapon
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_MG;
     }];
 
 //Bazooka Team
@@ -460,6 +373,7 @@
     US42_BzkaTL = ["US42_BzkaTL", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -482,6 +396,7 @@
     US42_BzkaG = ["US42_BzkaG", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -517,26 +432,15 @@
         US42_Weapon_VCom;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US42_Weapon_Secondary;
     }];
 
     //Tank Crew
     US42_VCrew = ["US42_VCrew", {
         params ["_unit"];
 
-        [
-            [
-                [US_Uni_CPL]
-            ],[40],
-            [
-                [US_Uni_PFC]
-            ],[50],
-            [
-                [US_Uni_PVT]
-            ],[10]
-        ] call Olsen_FW_FNC_AddItemRandomPercent;
+        [US_Vest_Pistol] call Olsen_FW_FNC_AddItem;
+        [US_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [US_BP_M1928] call Olsen_FW_FNC_AddItem;
         [US_Helm_VCrew] call Olsen_FW_FNC_AddItem;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
@@ -544,8 +448,8 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
 
-        //Weapon
-        US42_Weapon_VCrew;
+        //Secondary Weapon
+        US42_Weapon_Secondary;
 
         //Extra
         [GEN_Toolkit] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS42.sqf
@@ -233,6 +233,7 @@
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Automatic Rifleman
@@ -335,7 +336,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
         [US_Weap_M1919A4_T] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
@@ -345,6 +345,7 @@
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
         [US_Mag_M1919_250_Mixed_Ball,2] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
@@ -381,7 +382,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         US42_Weapon_Rifle_Light;
@@ -390,6 +390,7 @@
         [US_Mag_Bazoo,3,"backpack"] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Bazooka Gunner

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS44.sqf
@@ -206,7 +206,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        US44_Weapon_Rifle;
+        US44_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -254,6 +254,7 @@
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Automatic Rifleman
@@ -356,7 +357,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         US44_Weapon_Rifle;
@@ -365,6 +365,7 @@
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
         [US_Mag_M1919_250_Mixed_Ball,2] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
@@ -401,7 +402,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         US44_Weapon_Rifle_Light;
@@ -410,6 +410,7 @@
         [US_Mag_Bazoo,3,"backpack"] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Bazooka Gunner

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUS44.sqf
@@ -11,12 +11,12 @@
 [this, US44_PSGT] call Olsen_FW_FNC_GearScript;       Platoon Sergeant/Platoon Guide
 [this, US44_PRTO] call Olsen_FW_FNC_GearScript;       Radio Operator
 [this, US44_Mess] call Olsen_FW_FNC_GearScript;       Messenger
-[this, US44_MedP] call Olsen_FW_FNC_GearScript;        Medic
+[this, US44_MedP] call Olsen_FW_FNC_GearScript;       Medic
 
     //Squad
 [this, US44_SL] call Olsen_FW_FNC_GearScript;         Squad Leader
 [this, US44_S2] call Olsen_FW_FNC_GearScript;         Assistant Squad Leader
-[this, US44_MedS] call Olsen_FW_FNC_GearScript;      Assistant Medic
+[this, US44_MedS] call Olsen_FW_FNC_GearScript;       Assistant Medic
 [this, US44_AR] call Olsen_FW_FNC_GearScript;         Automatic Rifleman
 [this, US44_AAR] call Olsen_FW_FNC_GearScript;        Assistant Automatic Rifleman
 [this, US44_Rif] call Olsen_FW_FNC_GearScript;        Rifleman
@@ -43,33 +43,60 @@
                 [US_Mag_M1C,1], \
                 [US_Weap_M1C], \
                 [US_Mag_M1C,5,"vest"] \
-            ],[33], \
-            [ \
-                [US_Vest_M1T], \
-                [US_Mag_M3GG,1], \
-                [US_Weap_M3GG], \
-                [US_Mag_M3GG,5,"vest"] \
-            ],[33], \
+            ],[30], \
             [ \
                 [US_Vest_M1T], \
                 [US_Mag_M1T_30,1], \
                 [US_Weap_M1A1T], \
                 [US_Mag_M1T_30,5,"vest"] \
-            ],[34] \
+            ],[70] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
 
-// For light riflemen
+// For Radiomen, Messengers and Medics
 #define US44_Weapon_Rifle_Light \
         [US_Mag_M1C,1] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1C] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_M1C,10,"backpack"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1C,5,"backpack"] call Olsen_FW_FNC_AddItem;
 
-// For riflemen
+// For Automatic Riflemen
+#define US44_Weapon_AR \
+        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_BAR] call Olsen_FW_FNC_AddItem; \
+        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Riflemen
 #define US44_Weapon_Rifle \
         [US_Mag_M1G,1] call Olsen_FW_FNC_AddItem; \
         [US_Acc_M1_Bayo,1,"uniform"] call Olsen_FW_FNC_AddItem; \
         [US_Weap_M1G] call Olsen_FW_FNC_AddItem; \
-        [US_Mag_M1G,10,"backpack"] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1G,10,"backpack"] call Olsen_FW_FNC_AddItem;
+
+// For Tank Commander
+#define US44_Weapon_VCom \
+        [US_Vest_M1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_20,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1A1T] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1T_20,5,"vest"] call Olsen_FW_FNC_AddItem;
+
+// For Machinegunners
+#define US44_Weapon_MG \
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+
+// Colt M1911 Pistol
+#define US44_Weapon_Secondary \
+        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1911] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+
+// For Tank Crew
+#define US44_Weapon_M3GG \
+        [US_Mag_M3GG,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M3GG] call Olsen_FW_FNC_AddItem; \
+        [US_Mag_M3GG,3,"vest"] call Olsen_FW_FNC_AddItem;
 
 //======================== Loadouts ========================
 
@@ -91,9 +118,7 @@
         US44_Weapon_Leader;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -104,6 +129,7 @@
     US44_PSGT = ["US44_PSGT", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_SGT] call Olsen_FW_FNC_AddItem;
         [US_BP_M1928] call Olsen_FW_FNC_AddItem;
         [US_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
@@ -117,9 +143,7 @@
         US44_Weapon_Rifle_Light;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_Secondary;
 
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
@@ -130,6 +154,7 @@
     US44_PRTO = ["US44_PRTO", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [US_BP_M1928] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -151,6 +176,7 @@
     US44_Mess = ["US44_Mess", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -244,11 +270,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        [US_Mag_BAR_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_BAR] call Olsen_FW_FNC_AddItem;
-        [US_Acc_BAR_Bipod] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,6,"vest"] call Olsen_FW_FNC_AddItem;
-        [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_AR;
 
         //Extra
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
@@ -266,7 +288,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        [GEN_Bino] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         US44_Weapon_Rifle;
@@ -281,7 +302,7 @@
         params ["_unit"];
 
         [US_Uni_PFC] call Olsen_FW_FNC_AddItem;
-        [US_Vest_M1G] call Olsen_FW_FNC_AddItem;
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_BP_M1928] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -291,7 +312,7 @@
         GEN_MedicS_Equipment_Set;
 
         //Primary Weapon
-        US44_Weapon_Rifle;
+        US44_Weapon_Rifle_Light;
 
         //Extra
         [GEN_Gren_Frag_P,2] call Olsen_FW_FNC_AddItem;
@@ -360,14 +381,10 @@
         GEN_Default_Equipment_Set;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,2,"uniform"] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_Secondary;
 
         //Primary Weapon
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_MG;
     }];
 
 //Bazooka Team
@@ -376,6 +393,7 @@
     US44_BzkaTL = ["US44_BzkaTL", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_CPL] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -398,6 +416,7 @@
     US44_BzkaG = ["US44_BzkaG", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_PFC] call Olsen_FW_FNC_AddItem;
         [US_BP_AT] call Olsen_FW_FNC_AddItem;
         [US_Helm_r] call Olsen_FW_FNC_AddItemRandom;
@@ -421,6 +440,7 @@
     US44_VCom = ["US44_VCom", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_SGT] call Olsen_FW_FNC_AddItem;
         [US_Helm_VCrew] call Olsen_FW_FNC_AddItem;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
@@ -430,18 +450,17 @@
         GEN_Leader_Equipment_Set;
 
         //Primary Weapon
-        US44_Weapon_Leader;
+        US44_Weapon_M3GG;
 
         //Secondary Weapon
-        [US_Mag_M1911,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1911] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1911,3,"uniform"] call Olsen_FW_FNC_AddItem;
+        US44_Weapon_Secondary;
     }];
 
     //Tank Crew
     US44_VCrew = ["US44_VCrew", {
         params ["_unit"];
 
+        [US_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [US_Uni_PVT] call Olsen_FW_FNC_AddItem;
         [US_BP_M1928] call Olsen_FW_FNC_AddItem;
         [US_Helm_VCrew] call Olsen_FW_FNC_AddItem;
@@ -451,7 +470,7 @@
         GEN_Default_Equipment_Set;
 
         //Weapon
-        US44_Weapon_Leader;
+        US44_Weapon_M3GG;
 
         //Extra
         [GEN_Toolkit] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
@@ -218,6 +218,7 @@
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Automatic Rifleman
@@ -319,7 +320,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
         [US_Weap_M1919A4_T] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
@@ -329,6 +329,7 @@
         [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
@@ -365,7 +366,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         USMC42_Weapon_Rifle_Light;
@@ -374,6 +374,7 @@
         [US_Mag_Bazoo,3,"backpack"] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Bazooka Gunner

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC42.sqf
@@ -73,8 +73,9 @@
         [US_Mag_BAR_Mixed_Ball,9,"backpack"] call Olsen_FW_FNC_AddItem;
 
 // For Machinegunners
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
+#define USMC42_Weapon_MG \
+        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem; \
+        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem; \
         [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
 
 // Colt M1911 Pistol
@@ -347,9 +348,7 @@
         USMC42_Weapon_Secondary;
 
         //Primary Weapon
-        [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
-        [US_Weap_M1919A4] call Olsen_FW_FNC_AddItem;
-        [US_Mag_M1919_250_Mixed_Ball,3] call Olsen_FW_FNC_AddItem;
+        USMC42_Weapon_MG;
     }];
 
 //Bazooka Team

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSMC44.sqf
@@ -239,6 +239,7 @@
         //Extra
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Automatic Rifleman
@@ -338,7 +339,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         USMC44_Weapon_Leader;
@@ -347,6 +347,7 @@
         [US_Mag_M1919_250_Mixed_Ball,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
@@ -382,7 +383,6 @@
 
         //Assigned Items
         GEN_Default_Equipment_Set;
-        GEN_Leader_Equipment_Set;
 
         //Primary Weapon
         USMC44_Weapon_Leader;
@@ -391,6 +391,7 @@
         [US_Mag_Bazoo,3,"backpack"] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
         [GEN_Gren_Smoke_W,1] call Olsen_FW_FNC_AddItem;
+        [GEN_BinoUS] call Olsen_FW_FNC_AddItem;
     }];
 
     //Bazooka Gunner


### PR DESCRIPTION
- Added missing weapon definitions to US42 and US44, mainly for Automatic Rifleman, Radiomen Messengers and Medics, Tank Crew, Tank Commander, Machinegunners and Colt M1911 Pistol

- Updated US42 composition:

   - Removed M1919 MG from squads and replaced it with a BAR gunner like in US44

   - Removed no longer excisting Machinegun Assistant case (MGA) and replaced with Assistant Automatic Rifleman (AAR) 


- Changed Bazooka Team Olsen call from USMC42 to US42

- Added Machine Gun Team Leader and Machine Gunner to the loadout list in US42

- Changed weapon chance percentages for Weapon_Leader in US42 and US44 and Weapon_Rifle in US42

- Added M3 Grease gun to US44 Tank Crew

- Changed Thompson magazine size to 20 rounds in US42 to bring it in line with USMC42

- Changed M1903 Weapon_Rifle clip count from 20 to 12 in US42

- Removed vest from the following weapon cases in both US42 and US44: Weapon_Rifle_Light, US44_Weapon_Secondary

- Added USMC42_Weapon_MG to Machine Gunner loadout case in USMC42

Closes #14 