### PR TITLE
Add dynamic parachute assignment to USAB

### DIFF
--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/German/gearDefGerLuft.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/German/gearDefGerLuft.sqf
@@ -65,6 +65,7 @@
 #define FSJ_BP_Parachute				"B_LIB_GER_LW_Paradrop"
 
 //Parachute or backpack
+//spawnWithParachute variable is defined in the loadout files.
 #define FSJ_Backpack(unitType) \
         if (spawnWithParachute) then \
         { \

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUS.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUS.sqf
@@ -49,6 +49,9 @@
 
 #define USMC_Helm_VCrew         "H_LIB_US_Helmet_Tank"
 
+//Backpack
+#define US_BP_Radio             "fow_b_US_Radio"
+
 //===== US Air Force Equipment Definitions =====
 
 //Uniform

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSAfrica.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSAfrica.sqf
@@ -43,7 +43,6 @@
 #define US_BP_AT                "B_LIB_US_Backpack_RocketBag_Empty"
 #define US_BP_Med               "B_LIB_US_MedicBackpack_Big_Empty"
 #define US_BP_MG                "B_LIB_US_MGbag_Big_Empty"
-#define US_BP_Radio             "fow_b_US_Radio"
 #define US_BP_Flame             "B_LIB_US_M2Flamethrower"
 #define US_BP_Flame_Final       "B_LIB_US_M2Flamethrower_noLoad"
 #define US_Bando                "B_LIB_US_Bandoleer"

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSAirborne.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSAirborne.sqf
@@ -83,6 +83,7 @@
 #define USAB_Vest_Mort          "V_LIB_US_Vest_Medic"
 
 //Airborne Backpack
+#define USAB_BP_Parachute		"B_LIB_US_Type5"
 #define USAB_BP_r               ["B_LIB_US_M36"],["B_LIB_US_M36"],["B_LIB_US_M36_Rope"],["B_LIB_US_M36_Rope"]
 #define USAB_BP_M1928           "B_LIB_US_Backpack"
 #define USAB_BP_M36             "B_LIB_US_M36"
@@ -91,6 +92,41 @@
 #define USAB_BP_Med             "B_LIB_US_MedicBackpack_Big_Empty"
 #define USAB_BP_MG              "B_LIB_US_MGbag_Big_Empty"
 #define USAB_Bando              "B_LIB_US_Bandoleer"
+
+//Parachute or backpack
+//spawnWithParachute variable is defined in the loadout files.
+#define USAB_Backpack(unitType) \
+        if (spawnWithParachute) then \
+        { \
+            [USAB_BP_Parachute] call Olsen_FW_FNC_AddItem; \
+        } \
+        else \
+        { \
+            switch (unitType) do \
+            { \
+                case "MGTL": \
+                { \
+                    [USAB_BP_M1928] call Olsen_FW_FNC_AddItemRandom; \
+                }; \
+                case "MG": \
+                { \
+                    [USAB_BP_MG] call Olsen_FW_FNC_AddItemRandom; \
+                }; \
+				case "BzkaTL"; \
+				case "BzkaG": \
+                { \
+                    [USAB_BP_AT] call Olsen_FW_FNC_AddItemRandom; \
+                }; \
+				case "RTO": \
+                { \
+                    [US_BP_Radio] call Olsen_FW_FNC_AddItemRandom; \
+                }; \
+                default \
+                { \
+                    [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom; \
+                }; \
+            }; \
+        };
 
 //Airborne Headgear
 #define USAB_Helm_CPT_r         ["H_LIB_US_AB_Helmet_CO_1"],["H_LIB_US_AB_Helmet_CO_2"]

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSRegular.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSRegular.sqf
@@ -43,7 +43,6 @@
 #define US_BP_AT                "fow_b_us_rocket_bag"
 #define US_BP_Med               "B_LIB_US_MedicBackpack_Big_Empty"
 #define US_BP_MG                "B_LIB_US_MGbag_Big_Empty"
-#define US_BP_Radio             "fow_b_US_Radio"
 #define US_BP_Flame             "B_LIB_US_M2Flamethrower"
 #define US_BP_Flame_Final       "B_LIB_US_M2Flamethrower_noLoad"
 #define US_Bando                "fow_b_us_bandoleer"

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSWinter.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/US/gearDefUSWinter.sqf
@@ -43,7 +43,6 @@
 #define US_BP_AT                "fow_b_us_rocket_bag"
 #define US_BP_Med               "B_LIB_US_MedicBackpack_Big_Empty"
 #define US_BP_MG                "B_LIB_US_MGbag_Big_Empty"
-#define US_BP_Radio             "fow_b_US_Radio"
 #define US_BP_Flame             "B_LIB_US_M2Flamethrower"
 #define US_BP_Flame_Final       "B_LIB_US_M2Flamethrower_noLoad"
 #define US_Bando                "fow_b_us_bandoleer"

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSAB42.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSAB42.sqf
@@ -32,6 +32,11 @@
 
 //======================== Definitions ========================
 
+// ========================= Parachute ========================
+// Set the variable below to "true" or "false" depending on what you want
+
+#define spawnWithParachute false
+
 // For Platoon Commander, Squad Leader, Assistant Squad Leader
 #define USAB42_Weapon_Leader \
         [ \
@@ -101,6 +106,7 @@
         params ["_unit"];
 
         [USAB_UniK_LT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("PC");
         [USAB_Helm_2LT_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -124,7 +130,7 @@
         params ["_unit"];
 
         [USAB_UniK_SGT] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("PSGT");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -149,6 +155,7 @@
 
         [USAB_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USAB_UniK_PFC] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("Mess");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -169,7 +176,7 @@
 
         [USAB_UniK_Med] call Olsen_FW_FNC_AddItem;
         [US_Vest_Med] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Med");
         [USAB_Helm_Med_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -191,7 +198,7 @@
         params ["_unit"];
 
         [USAB_UniK_SGT] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("SL");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -212,7 +219,7 @@
         params ["_unit"];
 
         [USAB_UniK_CPL] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("S2");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -234,7 +241,7 @@
 
         [USAB_UniK_CPL] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_BAR] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("AR");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -254,7 +261,7 @@
 
         [USAB_UniK_PFC] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("AAR");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -276,7 +283,7 @@
 
         [USAB_UniK_PVT] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Med");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -298,7 +305,7 @@
 
         [USAB_UniK_PVT] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Rif");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -316,12 +323,13 @@
 //Machine Gun Team
 
     //Machine Gun Team Leader
+    // ======= WILL BE USELESS WHEN SPAWNED WITH A PARACHUTE =======
     USAB42_MGTL = ["USAB42_MGTL", {
         params ["_unit"];
 
         [USAB_UniK_CPL] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_M1928] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("MGTL");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -340,12 +348,13 @@
     }];
 
     //Machine Gunner
+    // ======= WILL BE USELESS WHEN SPAWNED WITH A PARACHUTE =======
     USAB42_MG = ["USAB42_MG", {
         params ["_unit"];
 
         [USAB_UniK_PFC] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_MGA] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_MG] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("MG");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -362,12 +371,13 @@
 //Bazooka Team
 
     //Bazooka Team Leader
+    // ======= SEVERALLY LIMITED IN AMMO WHEN SPAWNED WITH A PARACHUTE =======
     USAB42_BzkaTL = ["USAB42_BzkaTL", {
         params ["_unit"];
 
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
         [USAB_UniK_CPL] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_AT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("BzkaTL");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -385,12 +395,13 @@
     }];
 
     //Bazooka Gunner
+    // ======= SEVERALLY LIMITED IN AMMO WHEN SPAWNED WITH A PARACHUTE =======
     USAB42_BzkaG = ["USAB42_BzkaG", {
         params ["_unit"];
 
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
         [USAB_UniK_PFC] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_AT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("BzkaG");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSAB44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/US/gearUSAB44.sqf
@@ -33,6 +33,11 @@
 
 //======================== Definitions ========================
 
+// ========================= Parachute ========================
+// Set the variable below to "true" or "false" depending on what you want
+
+#define spawnWithParachute false
+
 // For Platoon Commander, Squad Leader, Assistant Squad Leader
 #define USAB44_Weapon_Leader \
         [US_Mag_M3GG,1] call Olsen_FW_FNC_AddItem; \
@@ -82,6 +87,7 @@
 
         [USAB_Vest_NCO_M1T] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_LT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("PC");
         [USAB_Helm_2LT_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -106,7 +112,7 @@
 
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_SGT] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("PSGT");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -131,7 +137,7 @@
 
         [USAB_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_CPL] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("RTO");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -153,6 +159,7 @@
 
         [USAB_Vest_M1C] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_PFC] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("Mess");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -173,7 +180,7 @@
 
         [USAB_UniG_Med] call Olsen_FW_FNC_AddItem;
         [US_Vest_Med] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Med");
         [USAB_Helm_Med_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -196,7 +203,7 @@
 
         [USAB_Vest_NCO_M1T] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_SGT] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("SL");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -218,7 +225,7 @@
 
         [USAB_Vest_M1T] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_CPL] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("S2");
         [USAB_Helm_NCO_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -240,7 +247,7 @@
 
         [USAB_UniG_CPL] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_BAR] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("AR");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -260,7 +267,7 @@
 
         [USAB_UniG_PFC] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("AAR");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -282,7 +289,7 @@
 
         [USAB_UniG_PVT] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Med");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -304,7 +311,7 @@
 
         [USAB_UniG_PVT] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_r] call Olsen_FW_FNC_AddItemRandom;
+        USAB_Backpack("Rif");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -322,12 +329,13 @@
 //Machine Gun Team
 
     //Machine Gun Team Leader
+    // ======= WILL BE USELESS WHEN SPAWNED WITH A PARACHUTE =======
     USAB44_MGTL = ["USAB44_MGTL", {
         params ["_unit"];
 
         [USAB_UniG_CPL] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_M1928] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("MGTL");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -346,12 +354,13 @@
     }];
 
     //Machine Gunner
+    // ======= WILL BE USELESS WHEN SPAWNED WITH A PARACHUTE =======
     USAB44_MG = ["USAB44_MG", {
         params ["_unit"];
 
         [USAB_UniG_PFC] call Olsen_FW_FNC_AddItem;
         [USAB_Vest_MGA] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_MG] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("MG");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -368,12 +377,13 @@
 //Bazooka Team
 
     //Bazooka Team Leader
+    // ======= SEVERALLY LIMITED IN AMMO WHEN SPAWNED WITH A PARACHUTE =======
     USAB44_BzkaTL = ["USAB44_BzkaTL", {
         params ["_unit"];
 
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_CPL] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_AT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("BzkaTL");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -391,12 +401,13 @@
     }];
 
     //Bazooka Gunner
+    // ======= SEVERALLY LIMITED IN AMMO WHEN SPAWNED WITH A PARACHUTE =======
     USAB44_BzkaG = ["USAB44_BzkaG", {
         params ["_unit"];
 
         [USAB_Vest_M1G] call Olsen_FW_FNC_AddItem;
         [USAB_UniG_PFC] call Olsen_FW_FNC_AddItem;
-        [USAB_BP_AT] call Olsen_FW_FNC_AddItem;
+        USAB_Backpack("BzkaG");
         [USAB_Helm_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 


### PR DESCRIPTION
Similar to the solution used in the Fallschirmjäger loadouts.

A single variable now controls if a USAB loadout will spawn with regular backpacks or parachutes.

(Also moved the US radio backpack to the generic US gearDef file)

Closes #38 