### PR TITLE
Remove FOW from Russian Loadouts

### DIFF
--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRus.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRus.sqf
@@ -5,25 +5,29 @@
 //========= Uniforms =========
 
 //Vests
-#define Rus_Vest_PC                             "V_LIB_SOV_RA_TankOfficerSet"
-#define Rus_Vest_PPSH_O_r                       ["V_LIB_SOV_RA_OfficerVest"],["V_LIB_SOV_RAZV_OfficerVest"]
+#define Rus_Vest_PC                             "V_NORTH_SOV_Belt_Officer"
+#define Rus_Vest_PPSH_O_r                       "V_NORTH_SOV_Belt_Officer"
 #define Rus_Vest_PPSH_D1                        "V_LIB_SOV_RA_PPShBelt"
 #define Rus_Vest_PPSH_D2                        "V_LIB_SOV_RAZV_PPShBelt"
 #define Rus_Vest_PPSH_S1                        "V_LIB_SOV_RA_PPShBelt_Mag"
 #define Rus_Vest_PPSH_S2                        "V_LIB_SOV_RAZV_PPShBelt_Mag"
-#define Rus_Vest_Mosin                          "V_LIB_SOV_RA_MosinBelt"
-#define Rus_Vest_SVT                            "V_LIB_SOV_RA_SVTBelt"
-#define Rus_Vest_MG_r                           ["V_LIB_SOV_RA_MGBelt"],["V_LIB_SOV_RAZV_MGBelt"]
-#define Rus_Vest_HGun                           "V_LIB_SOV_RA_MGBelt"
+#define Rus_Vest_Mosin                          "V_NORTH_SOV_Belt_Mosin_2"
+#define Rus_Vest_SVT                            "V_NORTH_SOV_Belt_Mosin_Imperial_4"
+#define Rus_Vest_MG                             "V_NORTH_SOV_Belt_Pistol_4"
+#define Rus_Vest_HGun                           "V_NORTH_SOV_Belt_Pistol_3"
 
 #define Rus_Vest_VCrew                          "V_LIB_GER_TankPrivateBelt"
 
 //Backpack
-#define Rus_BP                                  "B_LIB_SOV_RA_Rucksack"
+#define Rus_BP                                  "NORTH_SOV_Veshmeshok"
 
-#define Rus_BP_r                                ["B_LIB_SOV_RA_Rucksack"],["B_LIB_SOV_RA_Rucksack_Gas_Kit"],["B_LIB_SOV_RA_Rucksack2"],["B_LIB_SOV_RA_Rucksack2_Gas_Kit"],["B_LIB_SOV_RA_Rucksack2_Shinel"],["B_LIB_SOV_RA_Rucksack2_Gas_Kit_Shinel"],["B_LIB_SOV_RA_MGAmmoBag_Big_Empty"],["B_LIB_SOV_RA_GasBag"]
+#define Rus_BP_r                                ["NORTH_SOV_Veshmeshok"],["NORTH_SOV_Veshmeshok_Gasmaskbag"],["NORTH_SOV_Veshmeshok_2"],["NORTH_SOV_Veshmeshok_Gasmaskbag_2"],["NORTH_SOV_Veshmeshok_Shinel"],["NORTH_SOV_Veshmeshok_Gasmaskbag_Shinel"]
 
 #define Rus_BP_MG                               "B_LIB_SOV_RA_MGAmmoBag_Big_Empty"
 #define Rus_BP_Med                              "B_LIB_SOV_RA_MedicalBag_Big_Empty"
-#define Rus_BP_GB                               "B_LIB_SOV_RA_GasBag"
+#define Rus_BP_GB                               "NORTH_SOV_Gasmaskbag"
 #define Rus_BP_Radio                            "B_LIB_SOV_RA_Radio"
+
+//Facewear 
+#define Rus_Balaclava							"G_NORTH_SOV_Balaclava"
+#define Rus_Gloves								"G_NORTH_FIN_Gloves_4"

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusRegular.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusRegular.sqf
@@ -1,21 +1,38 @@
 //======================== Russian Regular Uniform Definitions ========================
 
-//Uniform
-#define Rus_Uni_BC                              "U_LIB_SOV_Kapitan"
-#define Rus_Uni_CC                              "U_LIB_SOV_Stleutenant"
-#define Rus_Uni_CSgt                            "U_LIB_SOV_Starshina"
-#define Rus_Uni_PC                              ["U_LIB_SOV_Leutenant"],["U_LIB_SOV_Leutenant_inset_pocket"]
-#define Rus_Uni_PSgt                            "U_LIB_SOV_Stsergeant"
-#define Rus_Uni_SL                              "U_LIB_SOV_Sergeant_inset_pocket"
-#define Rus_Uni_TL                              "U_LIB_SOV_Efreitor"
-#define Rus_Uni_Rif                             "U_LIB_SOV_Strelok"
+//1941 Uniforms
+#define Rus_Uni41_BC                            "U_NORTH_SOV_Obr35_Uniform_Cpt"
+#define Rus_Uni41_CC                            "U_NORTH_SOV_Obr35_Uniform_1stLt"
+#define Rus_Uni41_CSgt                          "U_NORTH_SOV_Obr35_Uniform_Lt"
+#define Rus_Uni41_PC                            "U_NORTH_SOV_Obr35_Uniform_2ndLt"
+#define Rus_Uni41_PSgt                          "U_NORTH_SOV_Obr35_Uniform_Staff_Sergeant"
+#define Rus_Uni41_SL                            "U_NORTH_SOV_Obr35_Uniform_Sergeant"
+#define Rus_Uni41_TL                            "U_NORTH_SOV_Obr35_Uniform_Corporal"
+#define Rus_Uni41_Rif                           "U_NORTH_SOV_Obr35_Uniform_Private_3"
 
+//1944 Uniforms
+#define Rus_Uni44_BC                            "U_NORTH_SOV_Obr43_Uniform_Cpt"
+#define Rus_Uni44_CC                            "U_NORTH_SOV_Obr43_Uniform_1stLt"
+#define Rus_Uni44_CSgt                          "U_NORTH_SOV_Obr43_Uniform_Lt"
+#define Rus_Uni44_PC                            "U_NORTH_SOV_Obr43_Uniform_2ndLt"
+#define Rus_Uni44_PSgt                          "U_NORTH_SOV_Obr43_Uniform_Staff_Sergeant"
+#define Rus_Uni44_SL                            "U_NORTH_SOV_Obr43_Uniform_Sergeant"
+#define Rus_Uni44_TL                            "U_NORTH_SOV_Obr43_Uniform_Corporal"
+#define Rus_Uni44_Rif                           "U_NORTH_SOV_Obr43_Uniform_Private_2"
+
+//Tank Crew
 #define Rus_Uni_VCom                            "U_LIB_SOV_Tank_leutenant"
 #define Rus_Uni_VCrew                           "U_LIB_SOV_Tank_ryadovoi"
 
 //Headgear
-#define Rus_Hat_PC                              "H_LIB_SOV_RA_OfficerCap"
-#define Rus_Hat                                 "H_LIB_SOV_RA_PrivateCap"
-#define Rus_Helmet                              "H_LIB_SOV_RA_Helmet"
+#define Rus_Hat_PC                              "H_NORTH_SOV_Obr35_Furazhka"
+#define Rus_Hat                                 "H_NORTH_SOV_Obr35_Pilotka"
+#define Rus_Helmet                              "H_NORTH_SOV_SSh39_Helmet_Moss_2"
 
-#define Rus_Hat_VCrew                           "H_LIB_SOV_TankHelmet"
+#define Rus_Helmet_r							["H_NORTH_SOV_SSh39_Helmet_Star"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"]
+
+#define Rus_Hat_VCrew_r                         ["H_NORTH_SOV_Tankerhelmet"],["H_NORTH_SOV_Tankerhelmet_open"]
+
+//Faceware
+#define Rus_Face \
+        [GEN_Face_WatchBlack] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusRegular.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusRegular.sqf
@@ -1,9 +1,8 @@
 //======================== Russian Regular Uniform Definitions ========================
 
 //1941 Uniforms
-#define Rus_Uni41_BC                            "U_NORTH_SOV_Obr35_Uniform_Cpt"
-#define Rus_Uni41_CC                            "U_NORTH_SOV_Obr35_Uniform_1stLt"
-#define Rus_Uni41_CSgt                          "U_NORTH_SOV_Obr35_Uniform_Lt"
+#define Rus_Uni41_CC                            "U_NORTH_SOV_Obr35_Uniform_Cpt"
+#define Rus_Uni41_CSgt                          "U_NORTH_SOV_Obr35_Uniform_Sergeant_Major"
 #define Rus_Uni41_PC                            "U_NORTH_SOV_Obr35_Uniform_2ndLt"
 #define Rus_Uni41_PSgt                          "U_NORTH_SOV_Obr35_Uniform_Staff_Sergeant"
 #define Rus_Uni41_SL                            "U_NORTH_SOV_Obr35_Uniform_Sergeant"
@@ -11,9 +10,8 @@
 #define Rus_Uni41_Rif                           "U_NORTH_SOV_Obr35_Uniform_Private_3"
 
 //1944 Uniforms
-#define Rus_Uni44_BC                            "U_NORTH_SOV_Obr43_Uniform_Cpt"
-#define Rus_Uni44_CC                            "U_NORTH_SOV_Obr43_Uniform_1stLt"
-#define Rus_Uni44_CSgt                          "U_NORTH_SOV_Obr43_Uniform_Lt"
+#define Rus_Uni44_CC                            "U_NORTH_SOV_Obr43_Uniform_Cpt"
+#define Rus_Uni44_CSgt                          "U_NORTH_SOV_Obr43_Uniform_Sergeant_Major_2"
 #define Rus_Uni44_PC                            "U_NORTH_SOV_Obr43_Uniform_2ndLt"
 #define Rus_Uni44_PSgt                          "U_NORTH_SOV_Obr43_Uniform_Staff_Sergeant"
 #define Rus_Uni44_SL                            "U_NORTH_SOV_Obr43_Uniform_Sergeant"
@@ -29,7 +27,7 @@
 #define Rus_Hat                                 "H_NORTH_SOV_Obr35_Pilotka"
 #define Rus_Helmet                              "H_NORTH_SOV_SSh39_Helmet_Moss_2"
 
-#define Rus_Helmet_r							["H_NORTH_SOV_SSh39_Helmet_Star"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"]
+#define Rus_Helmet_r			        ["H_NORTH_SOV_SSh39_Helmet_Star"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"],["H_NORTH_SOV_SSh39_Helmet_Moss_2"],["H_NORTH_SOV_SSh40_Helmet_3"]
 
 #define Rus_Hat_VCrew_r                         ["H_NORTH_SOV_Tankerhelmet"],["H_NORTH_SOV_Tankerhelmet_open"]
 

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWeapons.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWeapons.sqf
@@ -1,24 +1,25 @@
 //======================== Russian Weapon Definitions ========================
 
 //Primary
-#define Rus_Weap_MosM9130                       "LIB_M9130"
-#define Rus_Weap_MosM9130_S                     "LIB_M9130PU"
+#define Rus_Weap_MosM9130                       "NORTH_sov_M9130"
+#define Rus_Weap_MosM9130_LIB                   "LIB_M9130"
+#define Rus_Weap_MosM9130_S                     "NORTH_sov_M9130_PU"
 #define Rus_Weap_MosM38                         "LIB_M38"
 #define Rus_Weap_MosM44                         "LIB_M44"
-#define Rus_Weap_SVT40                          "LIB_SVT_40"
-#define Rus_Weap_AVT40                          "LIB_AVT_40_2PzD"
-#define Rus_Weap_PPD40                          "LIB_PPSh41_d"
-#define Rus_Weap_PPSH_S                         "LIB_PPSh41_m"
-#define Rus_Weap_PPSH_D                         "LIB_PPSh41_d"
-#define Rus_Weap_DP                             "LIB_DP28"
+#define Rus_Weap_SVT38                          "NORTH_SVT38"
+#define Rus_Weap_SVT40                          "NORTH_SVT40"
+#define Rus_Weap_AVT40                          "NORTH_AVT40"
+#define Rus_Weap_PPD40                          "NORTH_PPD40"
+#define Rus_Weap_PPSH                           "NORTH_ppsh41"
+#define Rus_Weap_DP                             "NORTH_dp27"
 #define Rus_Weap_DT                             "LIB_DT"
 #define Rus_Weap_DT_O                           "LIB_DT_OPTIC"
 #define Rus_Weap_PTRD                           "LIB_PTRD"
 #define Rus_Weap_PTRS                           "w39_urwz35"
 
 //Secondary
-#define Rus_Weap_TT33                           "LIB_TT33"
-#define Rus_Weap_M1895                          "LIB_M1895"
+#define Rus_Weap_TT33                           "NORTH_TT33"
+#define Rus_Weap_M1895                          "NORTH_m1895"
 
 //Launcher
 #define Rus_Weap_MortB                          "LIB_BM37_Barrel"
@@ -34,54 +35,18 @@
 
 //Ammo
 #define Rus_Mag_Mosin                           "LIB_5Rnd_762x54"
-#define Rus_Mag_Mosin_Heavy                     "LIB_5Rnd_762x54_D"
-#define Rus_Mag_Mosin_AP                        "LIB_5Rnd_762x54_b30"
-#define Rus_Mag_Mosin_Tracer_White              "LIB_5Rnd_762x54_t30"
-#define Rus_Mag_Mosin_Mixed_Ball_Tracer_White   "LIB_5Rnd_762x54_Mixed_Ball_t30_2PzD"
-#define Rus_Mag_Mosin_Mixed_Heavy_Tracer_White  "LIB_5Rnd_762x54_Mixed_HeavyBall_t30_2PzD"
-#define Rus_Mag_Mosin_Mixed_AP_Tracer_White     "LIB_5Rnd_762x54_Mixed_AP_t30_2PzD"
-#define Rus_Mag_Mosin_Tracer_Red                "LIB_5Rnd_762x54_t46"
-#define Rus_Mag_Mosin_Mixed_Ball_Tracer_Red     "LIB_5Rnd_762x54_Mixed_Ball_t46_2PzD"
-#define Rus_Mag_Mosin_Mixed_Heavy_Tracer_Red    "LIB_5Rnd_762x54_Mixed_HeavyBall_t46_2PzD"
-#define Rus_Mag_Mosin_Mixed_AP_Tracer_Red       "LIB_5Rnd_762x54_Mixed_AP_t46_2PzD"
+#define Rus_Mag_Mosin_Tracer                    "NORTH_5Rnd_m39_tracer_mag"
 
-#define Rus_Mag_SVT40                           "LIB_10Rnd_762x54"
-#define Rus_Mag_SVT40_Heavy                     "LIB_10Rnd_762x54_d"
-#define Rus_Mag_SVT40_AP                        "LIB_10Rnd_762x54_b30"
-#define Rus_Mag_SVT40_Tracer_White              "LIB_10Rnd_762x54_t30"
-#define Rus_Mag_SVT40_Mixed_Ball_Tracer_White   "LIB_10Rnd_762x54_t302"
-#define Rus_Mag_SVT40_Mixed_Heavy_Tracer_White  "LIB_10Rnd_762x54_Mixed_HeavyBall_t30_2PzD"
-#define Rus_Mag_SVT40_Mixed_AP_Tracer_White     "LIB_10Rnd_762x54_Mixed_AP_t30_2PzD"
-#define Rus_Mag_SVT40_Tracer_Red                "LIB_10Rnd_762x54_t46"
-#define Rus_Mag_SVT40_Mixed_Ball_Tracer_Red     "LIB_10Rnd_762x54_t462"
-#define Rus_Mag_SVT40_Mixed_Heavy_Tracer_Red    "LIB_10Rnd_762x54_Mixed_HeavyBall_t46_2PzD"
-#define Rus_Mag_SVT40_Mixed_AP_Tracer_Red       "LIB_10Rnd_762x54_Mixed_AP_t46_2PzD"
+#define Rus_Mag_SVT40                           "NORTH_10rnd_SVT_mag"
 
-#define Rus_Mag_PPD40                           "LIB_71Rnd_762x25"
-#define Rus_Mag_PPD40_AP                        "LIB_35Rnd_762x25_ap"
-#define Rus_Mag_PPD40_Tracer                    "LIB_35Rnd_762x25_t"
-#define Rus_Mag_PPD40_Mixed_Ball                "LIB_35Rnd_762x25_t2"
+#define Rus_Mag_PPD40                           "NORTH_71rnd_PPD40_mag"
 
-#define Rus_Mag_PPSH_S                          "LIB_35Rnd_762x25"
-#define Rus_Mag_PPSH_S_AP                       "LIB_35Rnd_762x25_ap"
-#define Rus_Mag_PPSH_S_Tracer                   "LIB_35Rnd_762x25_t"
-#define Rus_Mag_PPSH_S_Mixed_Ball               "LIB_35Rnd_762x25_t2"
-#define Rus_Mag_PPSH_D                          "LIB_71Rnd_762x25"
-#define Rus_Mag_PPSH_D_AP                       "LIB_71Rnd_762x25_ap"
-#define Rus_Mag_PPSH_D_Tracer                   "LIB_71Rnd_762x25_t"
-#define Rus_Mag_PPSH_D_Mixed_Ball               "LIB_71Rnd_762x25_t2"
+#define Rus_Mag_PPSH_S                          "NORTH_35rnd_ppsh41_mag"
+#define Rus_Mag_PPSH_D                          "NORTH_71rnd_ppsh41_mag"
 
-#define Rus_Mag_DP_Mixed_Ball_Red               "LIB_47Rnd_762x54"
-#define Rus_Mag_DP_Mixed_Heavy_Red              "LIB_47Rnd_762x54d"
-#define Rus_Mag_DP_Mixed_AP_Red                 "LIB_47Rnd_762x54_Mixed_AP_t46_2PzD"
-#define Rus_Mag_DP_Mixed_Ball_White             "LIB_47Rnd_762x54_Mixed_Ball_t30_2PzD"
-#define Rus_Mag_DP_Mixed_Heavy_White            "LIB_47Rnd_762x54_Mixed_HeavyBall_t30_2PzD"
-#define Rus_Mag_DP_Mixed_AP_White               "LIB_47Rnd_762x54_Mixed_AP_t30_2PzD"
-#define Rus_Mag_DP_Ball                         "LIB_47Rnd_762x54_noTrace_2PzD"
-#define Rus_Mag_DP_Heavy                        "LIB_47Rnd_762x54d_noTrace_2PzD"
-#define Rus_Mag_DP_AP                           "LIB_47Rnd_762x54_AP_noTrace_2PzD"
-#define Rus_Mag_DP_Tracer_White                 "LIB_47Rnd_762x54_t30_2PzD"
-#define Rus_Mag_DP_Tracer_Red                   "LIB_47Rnd_762x54_t46_2PzD"
+#define Rus_Mag_DP_Ball                         "NORTH_47rnd_dp27_mag"
+#define Rus_Mag_DP_Tracer                       "NORTH_47rnd_dp27_mag_Tracer"
+
 
 #define Rus_Mag_DT_Mixed_Ball_Red               "LIB_63Rnd_762x54"
 #define Rus_Mag_DT_Mixed_Heavy_Red              "LIB_63Rnd_762x54d"
@@ -99,12 +64,9 @@
 
 #define Rus_Mag_PTRS                            "w39_7_92_4x107DS"
 
-#define Rus_Mag_TT33                            "LIB_8Rnd_762x25"
-#define Rus_Mag_TT33_AP                         "LIB_8Rnd_762x25_APT"
-#define Rus_Mag_TT33_Tracer                     "LIB_8Rnd_762x25_Tracer_2PzD"
-#define Rus_Mag_TT33_Mixed_Ball_Tracer          "LIB_8Rnd_762x25_Mixed_Ball_Tracer_2PzD"
+#define Rus_Mag_TT33                            "NORTH_8Rnd_tt33_mag"
 
-#define Rus_Mag_M1895                           "LIB_7Rnd_762x38"
+#define Rus_Mag_M1895                           "NORTH_6Rnd_m1895_mag"
 
 #define Rus_Mag_RGrn_HE                         "LIB_1Rnd_G_DYAKONOV"
 #define Rus_Mag_Mort_HE                         "LIB_1Rnd_82mm_Mo_HE"
@@ -112,8 +74,9 @@
 #define Rus_Mag_Mort_Illum                      "LIB_1Rnd_82mm_Mo_Illum"
 
 //Grenades
-#define Rus_Gren_Frag_S                         "LIB_rg42"
-#define Rus_Gren_Frag_P                         "LIB_f1"
+#define Rus_Gren_Frag_S                         "NORTH_RG42Grenade_mag"
+#define Rus_Gren_Frag_S2                        "NORTH_RGD33Grenade_mag"
+#define Rus_Gren_Frag_P                         "NORTH_F1Grenade_mag"
 #define Rus_Gren_AT                             "LIB_rpg6"
 
 //Mines

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWeapons.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWeapons.sqf
@@ -8,7 +8,10 @@
 #define Rus_Weap_MosM44                         "LIB_M44"
 #define Rus_Weap_SVT38                          "NORTH_SVT38"
 #define Rus_Weap_SVT40                          "NORTH_SVT40"
+#define Rus_Weap_SVT40_S                        "NORTH_SVT40PU"
 #define Rus_Weap_AVT40                          "NORTH_AVT40"
+#define Rus_Weap_PPD34                          "NORTH_PPD34"
+#define Rus_Weap_PPD34_38                       "NORTH_PPD34_38"
 #define Rus_Weap_PPD40                          "NORTH_PPD40"
 #define Rus_Weap_PPSH                           "NORTH_ppsh41"
 #define Rus_Weap_DP                             "NORTH_dp27"
@@ -39,6 +42,10 @@
 
 #define Rus_Mag_SVT40                           "NORTH_10rnd_SVT_mag"
 
+#define Rus_Mag_PPD34                           "NORTH_34rnd_PPD_mag"
+
+#define Rus_Mag_PPD34_38                        "NORTH_71rnd_PPD34_38_mag"
+
 #define Rus_Mag_PPD40                           "NORTH_71rnd_PPD40_mag"
 
 #define Rus_Mag_PPSH_S                          "NORTH_35rnd_ppsh41_mag"
@@ -50,15 +57,6 @@
 
 #define Rus_Mag_DT_Mixed_Ball_Red               "LIB_63Rnd_762x54"
 #define Rus_Mag_DT_Mixed_Heavy_Red              "LIB_63Rnd_762x54d"
-#define Rus_Mag_DT_Mixed_AP_Red                 "LIB_63Rnd_762x54_Mixed_AP_t46_2PzD"
-#define Rus_Mag_DT_Mixed_Ball_White             "LIB_63Rnd_762x54_Mixed_Ball_t30_2PzD"
-#define Rus_Mag_DT_Mixed_Heavy_White            "LIB_63Rnd_762x54_Mixed_HeavyBall_t30_2PzD"
-#define Rus_Mag_DT_Mixed_AP_White               "LIB_63Rnd_762x54_Mixed_AP_t30_2PzD"
-#define Rus_Mag_DT_Ball                         "LIB_63Rnd_762x54_noTrace_2PzD"
-#define Rus_Mag_DT_Heavy                        "LIB_63Rnd_762x54d_noTrace_2PzD"
-#define Rus_Mag_DT_AP                           "LIB_63Rnd_762x54_AP_noTrace_2PzD"
-#define Rus_Mag_DT_Tracer_White                 "LIB_63Rnd_762x54_t30_2PzD"
-#define Rus_Mag_DT_Tracer_Red                   "LIB_63Rnd_762x54_t46_2PzD"
 
 #define Rus_Mag_PTRD                            "LIB_1Rnd_145x114"
 

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWinter.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWinter.sqf
@@ -1,21 +1,39 @@
 //======================== Russian Winter Uniform Definitions ========================
 
-//Uniform
-#define Rus_Uni_BC                              "U_LIB_SOV_Kapitan"
-#define Rus_Uni_CC                              "U_LIB_SOV_Stleutenant"
-#define Rus_Uni_CSgt                            "U_LIB_SOV_Sniper_w"
-#define Rus_Uni_PC                              ["U_LIB_SOV_Sniper_w"],["U_LIB_SOV_Sniper_w"]
-#define Rus_Uni_PSgt                            "U_LIB_SOV_Sniper_w"
-#define Rus_Uni_SL                              "U_LIB_SOV_Sniper_w"
-#define Rus_Uni_TL                              "U_LIB_SOV_Strelok_2_w"
-#define Rus_Uni_Rif                             "U_LIB_SOV_Strelok_w"
+//1941 Uniforms
+#define Rus_Uni41_BC                              "U_NORTH_SOV_Obr41_W_Greatcoat_Cpt"
+#define Rus_Uni41_CC                              "U_NORTH_SOV_Obr41_W_Greatcoat_1stLt"
+#define Rus_Uni41_CSgt                            "U_NORTH_SOV_Obr41_W_Greatcoat_Lt"
+#define Rus_Uni41_PC                              "U_NORTH_SOV_Obr41_W_Greatcoat_2ndLt"
+#define Rus_Uni41_PSgt                            "U_NORTH_SOV_Obr41_W_Greatcoat_Staff_Sergeant"
+#define Rus_Uni41_SL                              "U_NORTH_SOV_Obr41_W_Greatcoat_Sergeant"
+#define Rus_Uni41_TL                              "U_NORTH_SOV_Obr41_W_Greatcoat_Corporal"
+#define Rus_Uni41_Rif                             "U_NORTH_SOV_Obr41_W_Greatcoat_Private_4"
 
-#define Rus_Uni_VCom                            "U_LIB_SOV_Tank_leutenant"
-#define Rus_Uni_VCrew                           "U_LIB_SOV_Tank_ryadovoi"
+//1944 Uniforms
+#define Rus_Uni44_BC                              "U_NORTH_SOV_Obr31_W_Polushubuk"
+#define Rus_Uni44_CC                              "U_NORTH_SOV_Obr31_W_Polushubuk"
+#define Rus_Uni44_CSgt                            "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_PC                              "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_PSgt                            "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_SL                              "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_TL                              "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_Rif                             "U_NORTH_SOV_Obr37_43_W_MKK_5"
+
+//Tank Crew
+#define Rus_Uni_VCom                           	  "U_LIB_SOV_Tank_leutenant"
+#define Rus_Uni_VCrew                             "U_LIB_SOV_Tank_ryadovoi"
 
 //Headgear
-#define Rus_Hat_PC                              "H_LIB_SOV_Ushanka"
-#define Rus_Hat                                 "H_LIB_SOV_Ushanka"
+#define Rus_Hat_PC                              "H_NORTH_SOV_Obr40_Ushanka_fancy"
+#define Rus_Hat                                 "H_NORTH_SOV_Obr40_Ushanka"
 #define Rus_Helmet                              "H_LIB_SOV_RA_Helmet_w"
 
-#define Rus_Hat_VCrew                           "H_LIB_SOV_TankHelmet"
+#define Rus_Helmet_r							["H_LIB_SOV_RA_Helmet_w"],["H_NORTH_SOV_Obr40_Ushanka_2"],["H_NORTH_SOV_Obr31_Finka_2"],["H_NORTH_SOV_SSh40_Helmet_Winter_2"]
+
+#define Rus_Hat_VCrew_r                         ["H_NORTH_SOV_Tankerhelmet"],["H_NORTH_SOV_Tankerhelmet_open"]
+
+//Facewear
+#define Rus_Face \
+		[Rus_Balaclava] call Olsen_FW_FNC_AddItem; \
+        [Rus_Gloves] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWinter.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/geardefs/Russian/gearDefRusWinter.sqf
@@ -1,9 +1,8 @@
 //======================== Russian Winter Uniform Definitions ========================
 
 //1941 Uniforms
-#define Rus_Uni41_BC                              "U_NORTH_SOV_Obr41_W_Greatcoat_Cpt"
-#define Rus_Uni41_CC                              "U_NORTH_SOV_Obr41_W_Greatcoat_1stLt"
-#define Rus_Uni41_CSgt                            "U_NORTH_SOV_Obr41_W_Greatcoat_Lt"
+#define Rus_Uni41_CC                              "U_NORTH_SOV_Obr41_W_Greatcoat_Cpt"
+#define Rus_Uni41_CSgt                            "U_NORTH_SOV_Obr41_W_Greatcoat_Sergeant_Major"
 #define Rus_Uni41_PC                              "U_NORTH_SOV_Obr41_W_Greatcoat_2ndLt"
 #define Rus_Uni41_PSgt                            "U_NORTH_SOV_Obr41_W_Greatcoat_Staff_Sergeant"
 #define Rus_Uni41_SL                              "U_NORTH_SOV_Obr41_W_Greatcoat_Sergeant"
@@ -11,9 +10,8 @@
 #define Rus_Uni41_Rif                             "U_NORTH_SOV_Obr41_W_Greatcoat_Private_4"
 
 //1944 Uniforms
-#define Rus_Uni44_BC                              "U_NORTH_SOV_Obr31_W_Polushubuk"
 #define Rus_Uni44_CC                              "U_NORTH_SOV_Obr31_W_Polushubuk"
-#define Rus_Uni44_CSgt                            "U_NORTH_SOV_Obr37_43_W_MKK_5"
+#define Rus_Uni44_CSgt                            "U_NORTH_SOV_Obr31_W_Polushubuk"
 #define Rus_Uni44_PC                              "U_NORTH_SOV_Obr37_43_W_MKK_5"
 #define Rus_Uni44_PSgt                            "U_NORTH_SOV_Obr37_43_W_MKK_5"
 #define Rus_Uni44_SL                              "U_NORTH_SOV_Obr37_43_W_MKK_5"
@@ -25,13 +23,13 @@
 #define Rus_Uni_VCrew                             "U_LIB_SOV_Tank_ryadovoi"
 
 //Headgear
-#define Rus_Hat_PC                              "H_NORTH_SOV_Obr40_Ushanka_fancy"
-#define Rus_Hat                                 "H_NORTH_SOV_Obr40_Ushanka"
-#define Rus_Helmet                              "H_LIB_SOV_RA_Helmet_w"
+#define Rus_Hat_PC                               "H_NORTH_SOV_Obr40_Ushanka_fancy"
+#define Rus_Hat                                  "H_NORTH_SOV_Obr40_Ushanka"
+#define Rus_Helmet                               "H_LIB_SOV_RA_Helmet_w"
 
-#define Rus_Helmet_r							["H_LIB_SOV_RA_Helmet_w"],["H_NORTH_SOV_Obr40_Ushanka_2"],["H_NORTH_SOV_Obr31_Finka_2"],["H_NORTH_SOV_SSh40_Helmet_Winter_2"]
+#define Rus_Helmet_r						     ["H_LIB_SOV_RA_Helmet_w"],["H_NORTH_SOV_Obr40_Ushanka_2"],["H_NORTH_SOV_Obr31_Finka_2"],["H_NORTH_SOV_SSh40_Helmet_Winter_2"]
 
-#define Rus_Hat_VCrew_r                         ["H_NORTH_SOV_Tankerhelmet"],["H_NORTH_SOV_Tankerhelmet_open"]
+#define Rus_Hat_VCrew_r                          ["H_NORTH_SOV_Tankerhelmet"],["H_NORTH_SOV_Tankerhelmet_open"]
 
 //Facewear
 #define Rus_Face \

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus41.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus41.sqf
@@ -251,7 +251,7 @@
         params ["_unit"];
 
         [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
-        [Rus_Vest_Mosin] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Vest_Mosin] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
         Rus_Face;

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus41.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus41.sqf
@@ -45,7 +45,6 @@
                 [Rus_Vest_Mosin], \
                 [Rus_Mag_Mosin,1], \
                 [Rus_Weap_MosM9130], \
-                [Rus_Acc_Mos_Bayo], \
                 [Rus_Mag_Mosin,12,"vest"] \
             ],[70], \
             [/*SVT*/ \
@@ -85,10 +84,10 @@
     R41_PC = ["R41_PC", {
         params ["_unit"];
 
-        [Rus_Uni_PC] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Uni41_PC] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Vest_PC] call Olsen_FW_FNC_AddItem;
         [Rus_Hat_PC] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -104,10 +103,10 @@
     R41_PSgt = ["R41_PSgt", {
         params ["_unit"];
 
-        [Rus_Uni_SL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_SL] call Olsen_FW_FNC_AddItem;
         [Rus_BP] call Olsen_FW_FNC_AddItem;
-        [Rus_Hat] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat_PC] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -129,14 +128,14 @@
     R41_MedP = ["R41_MedP", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
         [Rus_BP_Med] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -149,7 +148,7 @@
     R41_Mess = ["R41_Mess", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -157,8 +156,8 @@
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
@@ -168,10 +167,10 @@
     R41_RTO = ["R41_RTO", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_Radio] call Olsen_FW_FNC_AddItem;
         [Rus_Hat] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
@@ -187,10 +186,10 @@
     R41_SL = ["R41_SL", {
         params ["_unit"];
 
-        [Rus_Uni_SL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_SL] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -201,21 +200,21 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Team Leader
     R41_TL = ["R41_TL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_TL] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -223,18 +222,18 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Submachine Gunner
     R41_SMG = ["R41_SMG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_PPSH_D1] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon
         R41_Weapon_SMG;
@@ -244,25 +243,25 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Grenadier
     R41_Gren = ["R41_Gren", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
-        [Rus_Vest_Mosin] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Vest_Mosin] call Olsen_FW_FNC_AddItemRandom;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
         [Rus_Mag_Mosin,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Weap_MosM9130] call Olsen_FW_FNC_AddItem;
+        [Rus_Weap_MosM9130_LIB] call Olsen_FW_FNC_AddItem;
         [Rus_Acc_Mos_GL] call Olsen_FW_FNC_AddItem;
         [Rus_Mag_Mosin,12,"vest"] call Olsen_FW_FNC_AddItem;
 
@@ -274,14 +273,14 @@
     R41_MedS = ["R41_MedS", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -296,14 +295,14 @@
     R41_Rif = ["R41_Rif", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -311,18 +310,18 @@
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
         [Rus_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
     R41_MG = ["R41_MG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_MG_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_BP_MG] call Olsen_FW_FNC_AddItem;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -331,31 +330,31 @@
         R41_Weapon_Secondary;
 
         //Primary Weapon
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_DP] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,3,"vest"] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,6,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,3,"vest"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,6,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //MG Assistant
     R41_MGA = ["R41_MGA", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon & Vest
         R41_Weapon_Rifleman;
 
         [Rus_BP_MG] call Olsen_FW_FNC_AddItem;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
 
         //Extra
-        [Rus_Mag_DP_Mixed_Ball_Red,6,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,6,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
 //Heavy Weapons Teams
@@ -364,11 +363,11 @@
     R41_HMGTL = ["R41_HMGTL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_TL] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_HGun] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_HMG_T] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -382,11 +381,11 @@
     R41_HMGG = ["R41_HMGG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_HGun] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_HMG_G] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -400,11 +399,11 @@
     R41_ATRTL = ["R41_ATRTL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_TL] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_PPSH_D1] call Olsen_FW_FNC_AddItem;
         [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon
         R41_Weapon_SMG;
@@ -422,11 +421,11 @@
     R41_ATRG = ["R41_ATRG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni41_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_PPSH_D1] call Olsen_FW_FNC_AddItem;
         [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -447,7 +446,7 @@
 
         [Rus_Uni_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_PC] call Olsen_FW_FNC_AddItem;
-        [Rus_Hat_VCrew] call Olsen_FW_FNC_AddItem;
+        [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items
@@ -470,7 +469,7 @@
         [Rus_Uni_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Hat_VCrew] call Olsen_FW_FNC_AddItem;
+        [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items

--- a/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus44.sqf
+++ b/missions/2PzD_Template_v3_0.VR/customization/loadouts/Russian/gearRus44.sqf
@@ -43,14 +43,14 @@
             [/*PPSh-41, Stick*/ \
                 [Rus_Vest_PPSH_S1], \
                 [Rus_Mag_PPSH_S,1], \
-                [Rus_Weap_PPSH_S], \
+                [Rus_Weap_PPSH], \
                 [Rus_Mag_PPSH_S,3,"vest"], \
                 [Rus_Mag_PPSH_D,2,"vest"] \
             ],[50], \
             [/*PPSh-41, Drum*/ \
                 [Rus_Vest_PPSH_D1], \
                 [Rus_Mag_PPSH_D,1], \
-                [Rus_Weap_PPSH_D], \
+                [Rus_Weap_PPSH], \
                 [Rus_Mag_PPSH_D,3,"vest"] \
             ],[50] \
         ] call Olsen_FW_FNC_AddItemRandomPercent;
@@ -97,9 +97,9 @@
     R44_PC = ["R44_PC", {
         params ["_unit"];
 
-        [Rus_Uni_PC] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Uni44_PC] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Hat_PC] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -116,10 +116,10 @@
     R44_PSgt = ["R44_PSgt", {
         params ["_unit"];
 
-        [Rus_Uni_SL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_SL] call Olsen_FW_FNC_AddItem;
         [Rus_BP] call Olsen_FW_FNC_AddItem;
-        [Rus_Hat] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat_PC] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -141,10 +141,10 @@
     R44_MedP = ["R44_MedP", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_Med] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Primary Weapon & Vest
         R44_Weapon_Rifleman;
@@ -160,9 +160,9 @@
     R44_Mess = ["R44_Mess", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -178,10 +178,9 @@
     R44_RTO = ["R44_RTO", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_Radio] call Olsen_FW_FNC_AddItem;
         [Rus_Hat] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Primary Weapon & Vest
         R44_Weapon_Rifleman
@@ -197,10 +196,10 @@
     R44_SL = ["R44_SL", {
         params ["_unit"];
 
-        [Rus_Uni_SL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_SL] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -211,17 +210,17 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Team Leader
     R44_TL = ["R44_TL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_TL] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon
         R44_Weapon_SMG;
@@ -232,17 +231,17 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Submachine Gunner
     R44_SMG = ["R44_SMG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon
         R44_Weapon_SMG;
@@ -252,18 +251,18 @@
 
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Grenadier
     R44_Gren = ["R44_Gren", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_Mosin] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -282,10 +281,10 @@
     R44_MedS = ["R44_MedS", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Hat] call Olsen_FW_FNC_AddItem;
+        Rus_Face;
 
         //Primary Weapon & Vest
         R44_Weapon_Rifleman;
@@ -303,10 +302,10 @@
     R44_Rif = ["R44_Rif", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon & Vest
         R44_Weapon_Rifleman;
@@ -317,37 +316,37 @@
         //Extra
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
         [Rus_Gren_Frag_P,1] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Machine Gunner
     R44_MG = ["R44_MG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_MG_r] call Olsen_FW_FNC_AddItemRandom;
         [Rus_BP_MG] call Olsen_FW_FNC_AddItem;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        [Rus_Mag_DP_Mixed_Ball_Red,1] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,1] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_DP] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,3,"vest"] call Olsen_FW_FNC_AddItem;
-        [Rus_Mag_DP_Mixed_Ball_Red,6,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,3,"vest"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,6,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //MG Assistant
     R44_MGA = ["R44_MGA", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_BP_MG] call Olsen_FW_FNC_AddItem;
         [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon & Vest
         R44_Weapon_Rifleman;
@@ -357,7 +356,7 @@
         [Rus_Gren_Frag_S,1] call Olsen_FW_FNC_AddItem;
 
         //Extra
-        [Rus_Mag_DP_Mixed_Ball_Red,6,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_DP_Tracer,6,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
 //Heavy Weapons Teams
@@ -366,11 +365,11 @@
     R44_HMGTL = ["R44_HMGTL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_TL] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_HGun] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_HMG_T] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -384,11 +383,11 @@
     R44_HMGG = ["R44_HMGG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_HGun] call Olsen_FW_FNC_AddItem;
         [Rus_Weap_HMG_G] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -402,10 +401,10 @@
     R44_ATRTL = ["R44_ATRTL", {
         params ["_unit"];
 
-        [Rus_Uni_TL] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_TL] call Olsen_FW_FNC_AddItem;
         [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Primary Weapon
         R44_Weapon_SMG;
@@ -423,10 +422,10 @@
     R44_ATRG = ["R44_ATRG", {
         params ["_unit"];
 
-        [Rus_Uni_Rif] call Olsen_FW_FNC_AddItem;
+        [Rus_Uni44_Rif] call Olsen_FW_FNC_AddItem;
         [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
-        [Rus_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
+        Rus_Face;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -446,7 +445,7 @@
         params ["_unit"];
 
         [Rus_Uni_VCrew] call Olsen_FW_FNC_AddItem;
-        [Rus_Hat_VCrew] call Olsen_FW_FNC_AddItem;
+        [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items
@@ -467,7 +466,7 @@
         [Rus_Uni_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Vest_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Rus_Hat_VCrew] call Olsen_FW_FNC_AddItem;
+        [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items


### PR DESCRIPTION
-Removed FOW items (zero to begin with)

-Replaced IFA equipment with NF equipment

Closes #48
Closes #54   
Closes #50 