### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @DarkMessiah27
+# *   @DarkMessiah27


### PR DESCRIPTION
Commenting out CODEOWNERS entry for now as it's no longer necessary. May uncomment and reinstate required code owner review at a later date when more contributors join.