### PR TITLE
CBA settings edit permissions

### DIFF
--- a/missions/2PzD_Template.VR/core/description.hpp
+++ b/missions/2PzD_Template.VR/core/description.hpp
@@ -14,7 +14,7 @@
     enableTargetDebug = 1; //Enable CBA Target Debugging - This allows debugging on non-local machines.
     unsafeCVL = 1;
     cba_settings_whitelist[] = {"76561198006804011","76561198028284438","76561197983143701","76561197985738940","76561198096113294","76561197989925440"};
-    // This locks Server and mission CBA_Settings to only be changed by the UID that is listed. Changing this requires Council permision.
+    // This locks Server and mission CBA_Settings to only be changed by the UID that is listed.
 
     class Extended_PreInit_EventHandlers {
         class Mission {

--- a/missions/2PzD_Template.VR/core/description.hpp
+++ b/missions/2PzD_Template.VR/core/description.hpp
@@ -13,8 +13,8 @@
     // enableDebugConsole = 1; // 1 = Only for logged-in admins - This setting is superseded by the array above.
     enableTargetDebug = 1; //Enable CBA Target Debugging - This allows debugging on non-local machines.
     unsafeCVL = 1;
+    // This locks Server and mission CBA_Settings to only be changed by the UID that is listed. This is enabled for Brauer, Feld, Madsen, Sauer, Schuttler, and Falk by default.
     cba_settings_whitelist[] = {"76561198006804011","76561198028284438","76561197983143701","76561197985738940","76561198096113294","76561197989925440"};
-    // This locks Server and mission CBA_Settings to only be changed by the UID that is listed.
 
     class Extended_PreInit_EventHandlers {
         class Mission {

--- a/missions/2PzD_Template.VR/core/description.hpp
+++ b/missions/2PzD_Template.VR/core/description.hpp
@@ -13,6 +13,8 @@
     // enableDebugConsole = 1; // 1 = Only for logged-in admins - This setting is superseded by the array above.
     enableTargetDebug = 1; //Enable CBA Target Debugging - This allows debugging on non-local machines.
     unsafeCVL = 1;
+    cba_settings_whitelist[] = {"76561198006804011","76561198028284438","76561197983143701","76561197985738940","76561198096113294","76561197989925440"};
+    // This locks Server and mission CBA_Settings to only be changed by the UID that is listed. Changing this requires Council permision.
 
     class Extended_PreInit_EventHandlers {
         class Mission {


### PR DESCRIPTION
This PR will add a check on who has the ability to change the CBA_Settings that are not forced by the Cba_Settings.sqf on the server as some of our settings have reasons for not being forced but still can cause harm towards the mission if changed.

It will only prevent changes to Server and Mission Settings so players are still able to change client settings

a small Comment has also been added to explain the setting in minor details.