### PR TITLE
Tweaks to the Russian loadouts

### DIFF
--- a/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus39.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus39.sqf
@@ -535,6 +535,7 @@
         [Rus_Vest_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_BP39] call Olsen_FW_FNC_AddItem;
 
         //Assigned Items
         GEN_Default_Equipment_Set;

--- a/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus41.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus41.sqf
@@ -535,6 +535,7 @@
         [Rus_Vest_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_BP39] call Olsen_FW_FNC_AddItem;
 
         //Assigned Items
         GEN_Default_Equipment_Set;

--- a/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus44.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/Russian/loadoutRus44.sqf
@@ -48,7 +48,6 @@
                 [Rus_Vest_Mosin], \
                 [Rus_Mag_Mosin,1], \
                 [Rus_Weap_MosM9130], \
-                [Rus_Acc_Mos_Bayo], \
                 [Rus_Mag_Mosin,12,"vest"] \
             ],[70], \
             [/*SVT*/ \
@@ -538,6 +537,7 @@
         [Rus_Vest_VCrew] call Olsen_FW_FNC_AddItem;
         [Rus_Hat_VCrew_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_Tank_r] call Olsen_FW_FNC_AddItemRandom;
+        [Rus_BP39] call Olsen_FW_FNC_AddItem;
 
         //Assigned Items
         GEN_Default_Equipment_Set;

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutRUS.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutRUS.sqf
@@ -13,6 +13,7 @@
     [Rus_Mag_Mosin, 25] call Olsen_FW_FNC_AddItemVehicle; \
     [Rus_Mag_DP_Tracer, 10] call Olsen_FW_FNC_AddItemVehicle; \
     [Rus_Mag_PPSH_S, 6] call Olsen_FW_FNC_AddItemVehicle; \
+    [Rus_Mag_PPD40, 6] call Olsen_FW_FNC_AddItemVehicle; \
     [Rus_Mag_SVT, 10] call Olsen_FW_FNC_AddItemVehicle; \
     [GEN_Gren_Frag_P, 10] call Olsen_FW_FNC_AddItemVehicle; \
     [Rus_Gren_Frag_S, 10] call Olsen_FW_FNC_AddItemVehicle; \


### PR DESCRIPTION
Changes:

Added Backpacks to Tank crew
Removed Bayonets from the russian loadouts as they are not compatible with the NF weapons | The define is still there
Added PPD40 ammo to the Vehicle loadout.