### PR TITLE
Loadout Changes for SWT

### DIFF
--- a/missions/2PzD_Template.VR/customization/loadouts/British/loadoutUK40.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/British/loadoutUK40.sqf
@@ -353,7 +353,7 @@
 
         [UK_Uni_Cpl] call Olsen_FW_FNC_AddItem;
         [UK_VestK_LeeEn] call Olsen_FW_FNC_AddItem;
-        [UK_BP_S] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [UK_Helm_Mk2_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -376,20 +376,19 @@
 
         [UK_Uni_Pte] call Olsen_FW_FNC_AddItem;
         [UK_VestK_O] call Olsen_FW_FNC_AddItem;
-        [UK_BP] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [UK_Helm_Mk2_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
 
-        //Secondary Weapon
-        UK40_Webley;
-
         //Primary Weapon
-        [UK_Mag_Boys,1] call Olsen_FW_FNC_AddItem;
-        [UK_Weap_Boys] call Olsen_FW_FNC_AddItem;
-        [UK_Mag_Boys,5] call Olsen_FW_FNC_AddItem;
+        UK40_LeeEn;
+
+        //Extra
+        [UK_Weap_Boys,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [UK_Mag_Boys,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Recon Team leader

--- a/missions/2PzD_Template.VR/customization/loadouts/British/loadoutUK44.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/British/loadoutUK44.sqf
@@ -353,7 +353,7 @@
 
         [UK_Uni_Cpl] call Olsen_FW_FNC_AddItem;
         [UK_VestK_LeeEn] call Olsen_FW_FNC_AddItem;
-        [UK_BP] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [UK_Helm_Mk2_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
@@ -376,20 +376,19 @@
 
         [UK_Uni_Pte] call Olsen_FW_FNC_AddItem;
         [UK_VestK_O] call Olsen_FW_FNC_AddItem;
-        [UK_BP] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [UK_Helm_Mk2_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
 
-        //Secondary Weapon
-        UK44_Webley;
-
         //Primary Weapon
-        [UK_Mag_Boys,1] call Olsen_FW_FNC_AddItem;
-        [UK_Weap_Boys] call Olsen_FW_FNC_AddItem;
-        [UK_Mag_Boys,5] call Olsen_FW_FNC_AddItem;
+        UK44_LeeEn;
+
+        //Extra
+        [UK_Weap_Boys,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [UK_Mag_Boys,5,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Recon Team Leader

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
@@ -459,7 +459,7 @@
 
         //Primary Weapon
         [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_sS,1,] call Olsen_FW_FNC_AddItem;
+        [Ger_Mag_MG_50_Mixed_sS,1] call Olsen_FW_FNC_AddItem;
 
         //Extra
         [Ger_Mag_MG_50_Mixed_sS,10] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
@@ -458,7 +458,7 @@
         WHR39_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem;
+        [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem; //Needs to be specified, as the MG30 is not combatible with the Tripod.
         [Ger_Mag_MG_50_Mixed_sS,1] call Olsen_FW_FNC_AddItem;
 
         //Extra

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR39.sqf
@@ -26,7 +26,6 @@
     //Weapon Truppen
 [this, WHR39_HMGSL] call Olsen_FW_FNC_GearScript;        HMG Truppführer
 [this, WHR39_HMGG] call Olsen_FW_FNC_GearScript;         HMG Richtschütze
-[this, WHR39_HMGA] call Olsen_FW_FNC_GearScript;         HMG Munitionsträger
 
     //Recon
 [this, WHR39_RCTL] call Olsen_FW_FNC_GearScript;         Recon Truppführer
@@ -431,7 +430,6 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
         GEN_Leader_Equipment_Set;
-        [GEN_ace_sparebarrel] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         WHR39_Weapon_Rifleman;
@@ -460,11 +458,11 @@
         WHR39_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_sS,5] call Olsen_FW_FNC_AddItem;
         [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_sS,20,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Ger_Mag_MG_50_Mixed_sS,1,] call Olsen_FW_FNC_AddItem;
 
         //Extra
+        [Ger_Mag_MG_50_Mixed_sS,10] call Olsen_FW_FNC_AddItem;
     }];
 
     //Recon Team leader

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR40.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR40.sqf
@@ -26,7 +26,6 @@
     //Weapon Truppen
 [this, WHR40_HMGSL] call Olsen_FW_FNC_GearScript;     HMG Truppführer
 [this, WHR40_HMGG] call Olsen_FW_FNC_GearScript;      HMG Richtschütze
-[this, WHR40_HMGA] call Olsen_FW_FNC_GearScript;      HMG Munitionsträger
 
     //Recon
 [this, WHR40_RCTL] call Olsen_FW_FNC_GearScript;      Recon Truppführer
@@ -389,7 +388,6 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
         GEN_Leader_Equipment_Set;
-        [GEN_ace_sparebarrel] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         WHR40_Weapon_Rifleman;
@@ -418,34 +416,11 @@
         WHR40_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_sS,5] call Olsen_FW_FNC_AddItem;
+        [Ger_Mag_MG_50_Mixed_sS,1] call Olsen_FW_FNC_AddItem;
         [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_sS,5] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_sS,3] call Olsen_FW_FNC_AddItem;
 
         //Extra
         [Ger_Mag_MG_50_Mixed_sS,10] call Olsen_FW_FNC_AddItem;
-    }];
-
-    //HMG Munitionsträger
-    WHR40_HMGA = ["WHR40_HMGA", {
-        params ["_unit"];
-
-        [Ger_Uni_Rif_E_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_Vest_K98] call Olsen_FW_FNC_AddItem;
-        [Ger_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_Helmet] call Olsen_FW_FNC_AddItem;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
-
-        //Assigned Items
-        GEN_Default_Equipment_Set;
-
-        //Primary Weapon
-        WHR40_Weapon_Rifleman;
-
-        //Extra
-        [Ger_Mag_MG_50_Mixed_sS,10] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_sS,5] call Olsen_FW_FNC_AddItem;
     }];
 
     //Recon Team leader

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR40.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR40.sqf
@@ -404,7 +404,6 @@
         params ["_unit"];
 
         [Ger_Uni_Rif_E_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_Vest_MG] call Olsen_FW_FNC_AddItem;
         [Ger_BP_r] call Olsen_FW_FNC_AddItemRandom;
         [Ger_Helmet] call Olsen_FW_FNC_AddItem;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -416,8 +415,7 @@
         WHR40_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_sS,1] call Olsen_FW_FNC_AddItem;
-        [Ger_Weap_MG34] call Olsen_FW_FNC_AddItem;
+        WHR40_Weapon_MG;
 
         //Extra
         [Ger_Mag_MG_50_Mixed_sS,10] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR42.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR42.sqf
@@ -26,7 +26,6 @@
     //HMG Team
 [this, WHR42_HMGSL] call Olsen_FW_FNC_GearScript;     HMG Truppführer
 [this, WHR42_HMGG] call Olsen_FW_FNC_GearScript;      HMG Richtschütze
-[this, WHR42_HMGA] call Olsen_FW_FNC_GearScript;      HMG Munitionsträger
 
     //Recon
 [this, WHR42_RCTL] call Olsen_FW_FNC_GearScript;      Recon Truppführer
@@ -386,7 +385,6 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
         GEN_Leader_Equipment_Set;
-        [GEN_ace_sparebarrel] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         WHR42_Weapon_Rifleman;
@@ -415,10 +413,7 @@
         WHR42_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_SmE,5] call Olsen_FW_FNC_AddItem;
         WHR42_Weapon_MG;
-        [Ger_Mag_MG_50_Mixed_SmE,5] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_SmE,3] call Olsen_FW_FNC_AddItem;
 
         //Extra
         [Ger_Mag_MG_50_Mixed_SmE,10] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR44.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR44.sqf
@@ -26,12 +26,10 @@
     //Weapon Truppen
 [this, WHR44_HMGSL] call Olsen_FW_FNC_GearScript;     HMG Truppführer
 [this, WHR44_HMGG] call Olsen_FW_FNC_GearScript;      HMG Richtschütze
-[this, WHR44_HMGA] call Olsen_FW_FNC_GearScript;      HMG Munitionsträger
 
     //Panzerschreck
 [this, WHR44_ATSL] call Olsen_FW_FNC_GearScript;      Panzerschreck Truppführer
 [this, WHR44_ATG] call Olsen_FW_FNC_GearScript;       Panzerschreck Richtschütze
-[this, WHR44_ATA] call Olsen_FW_FNC_GearScript;       Panzerschreck Munitionsträger
 
     //Recon
 [this, WHR44_RCTL] call Olsen_FW_FNC_GearScript;      Recon Truppführer
@@ -404,7 +402,6 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
         GEN_Leader_Equipment_Set;
-        [GEN_ace_sparebarrel] call Olsen_FW_FNC_AddItem;
 
         //Primary Weapon
         WHR44_Weapon_Rifleman;
@@ -433,33 +430,11 @@
         WHR44_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_SmE,5] call Olsen_FW_FNC_AddItem;
+        [Ger_Mag_MG_50_Mixed_SmE,1] call Olsen_FW_FNC_AddItem;
         WHR44_Weapon_MG;
-        [Ger_Mag_MG_50_Mixed_SmE,5] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_SmE,3] call Olsen_FW_FNC_AddItem;
 
         //Extra
         [Ger_Mag_MG_50_Mixed_SmE,10] call Olsen_FW_FNC_AddItem;
-    }];
-
-    //HMG Munitionsträger
-    WHR44_HMGA = ["WHR44_HMGA", {
-        params ["_unit"];
-
-        [Ger_Uni_Rif_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_BP_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
-
-        //Assigned Items
-        GEN_Default_Equipment_Set;
-
-        //Primary Weapon
-        WHR44_Weapon_Rifleman;
-
-        //Extra
-        [Ger_Mag_MG_50_Mixed_SmE,10] call Olsen_FW_FNC_AddItem;
-        [Ger_Mag_MG_50_Mixed_SmE,3] call Olsen_FW_FNC_AddItem;
     }];
 
     //Panzerschreck Team
@@ -468,6 +443,7 @@
         params ["_unit"];
 
         [Ger_Uni_S3_L] call Olsen_FW_FNC_AddItem;
+        [Ger_Vest_SL] call Olsen_FW_FNC_AddItem;
         [Ger_BP_Pzr] call Olsen_FW_FNC_AddItem;
         [Ger_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -489,29 +465,6 @@
         params ["_unit"];
 
         [Ger_Uni_Rif_r] call Olsen_FW_FNC_AddItemRandom;
-        [Ger_Vest_HGun] call Olsen_FW_FNC_AddItem;
-        [Ger_BP_Pzr] call Olsen_FW_FNC_AddItem;
-        [Ger_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
-        [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
-
-        //Assigned Items
-        GEN_Default_Equipment_Set;
-
-        //Secondary Weapon
-        WHR44_Weapon_Secondary;
-
-        //Launcher
-        [Ger_Weap_Pzschrck] call Olsen_FW_FNC_AddItem;
-
-        //Extra
-        [Ger_Mag_Pzschrck,5] call Olsen_FW_FNC_AddItem;
-    }];
-
-    //Panzerschreck Munitionsträger
-    WHR44_ATA = ["WHR44_ATA", {
-        params ["_unit"];
-
-        [Ger_Uni_Rif_r] call Olsen_FW_FNC_AddItemRandom;
         [Ger_BP_Pzr] call Olsen_FW_FNC_AddItem;
         [Ger_Helmet_r] call Olsen_FW_FNC_AddItemRandom;
         [GEN_Face_r] call Olsen_FW_FNC_AddItemRandom;
@@ -521,6 +474,9 @@
 
         //Primary Weapon
         WHR44_Weapon_Rifleman;
+
+        //Launcher
+        [Ger_Weap_Pzschrck] call Olsen_FW_FNC_AddItem;
 
         //Extra
         [Ger_Mag_Pzschrck,5] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR44.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/German/loadoutWHR44.sqf
@@ -430,7 +430,6 @@
         WHR44_Weapon_Secondary;
 
         //Primary Weapon
-        [Ger_Mag_MG_50_Mixed_SmE,1] call Olsen_FW_FNC_AddItem;
         WHR44_Weapon_MG;
 
         //Extra


### PR DESCRIPTION
Changed out the backpack to make room for a normal Primary weapon for UK 40 and 44

Cleaned up the HMG section for WHR:
- Removed all Mentions of Munitionstragers
- Removed all Sparebarrels
- Cleaned up MG Gunners
- Gave Panzerschreck TL a vest
- Gave Panzerschreck Gunner a Main Weapon /Removed Pistol.

This closes #112