### PR TITLE
Remove Zeus from supporting fires module

### DIFF
--- a/missions/2PzD_Template.VR/modules/supporting_fires/actions.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/actions.sqf
@@ -3,13 +3,12 @@
 _supportingFireActions = call {
 
     // Add conditions for interactions
-    _conditionFires = {supportFire_isZEUS || {call acre_api_fnc_getCurrentRadio != ""}};
+    _conditionFires = {call acre_api_fnc_getCurrentRadio != ""};
 
     _conditionTargets = {
             supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_shellsHE_AmmoCountWEST > 0 || supportFire_shellsSmoke_AmmoCountWEST > 0 || supportFire_shellsFlare_AmmoCountWEST > 0}
         || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_shellsHE_AmmoCountEAST > 0 || supportFire_shellsSmoke_AmmoCountEAST > 0 || supportFire_shellsFlare_AmmoCountEAST > 0}}
         || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_shellsHE_AmmoCountGUER > 0 || supportFire_shellsSmoke_AmmoCountGUER > 0 || supportFire_shellsFlare_AmmoCountGUER > 0}}
-        || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
     };
 
     _conditionVisual = {
@@ -18,7 +17,6 @@ _supportingFireActions = call {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
         }
     };
 
@@ -28,7 +26,6 @@ _supportingFireActions = call {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
         }
     };
 
@@ -36,19 +33,17 @@ _supportingFireActions = call {
             supportFire_isWEST && {supportFire_fireMissionAvailableWEST}
         || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST}}
         || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER}}
-        || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
     };
 
     _conditionFiring = {
             supportFire_isWEST && {!supportFire_fireMissionAvailableWEST}
         || {supportFire_isEAST && {!supportFire_fireMissionAvailableEAST}}
         || {supportFire_isGUER && {!supportFire_fireMissionAvailableGUER}}
-        || {supportFire_isZEUS && {!supportFire_fireMissionAvailableZEUS}}
     };
 
     // ===== Add supporting fires interaction
     _statementFires = {
-        if (!supportFire_isZEUS && {supportFire_iscivilian}) then {
+        if (supportFire_iscivilian) then {
             [["Return possession of this radio to the appropriate military authorities!"], true] call CBA_fnc_notify;
         } else {
             [["Select a target, type of ammunition, and number of rounds, then call the fire mission."], true] call CBA_fnc_notify;
@@ -56,25 +51,16 @@ _supportingFireActions = call {
     };
     _actionFires = ["Supporting Fires","Supporting Fires","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementFires,_conditionFires] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions"], _actionFires] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions"], _actionFires] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     // ===== Add action to check remaining ammunition
     _statementRounds = {[] call Olsen_FW_FNC_SupportFire_AmmoCheck;};
     _actionRounds = ["Check Ammo Supply","Check Ammo Supply","Haas_WWII_Rebalance\UI\icon_supporting_fires_ammo.paa",_statementRounds,_conditionCheck] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionRounds] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionRounds] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     // ===== Add action to indicate fire mission is in progress.
     _statementFiring = {[["Fire mission is already underway."], true] call CBA_fnc_notify;};
     _actionFiring = ["Fire Mission In Progress","Fire Mission In Progress","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementFiring,_conditionFiring] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionFiring] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionFiring] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     // ===== Add Targets
     #include "actions\Targets.sqf"
@@ -94,9 +80,6 @@ _supportingFireActions = call {
     };
     _actionSafety = ["Call for Fire","Call for Fire","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementSafety,_conditionTargets] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionSafety] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionSafety] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     // ===== Add Fire Mission
     _statementFireMission = {
@@ -104,9 +87,6 @@ _supportingFireActions = call {
     };
     _actionFireMission = ["Confirm!","Confirm!","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementFireMission,{true}] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires","Call for Fire"], _actionFireMission] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires","Call for Fire"], _actionFireMission] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
 };
 // End Actions

--- a/missions/2PzD_Template.VR/modules/supporting_fires/actions/AdjustFire.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/actions/AdjustFire.sqf
@@ -14,9 +14,6 @@
     };
     _actionAdjust = ["Adjust Fire","Adjust Fire","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjust.paa",_statementAdjust,_conditionAdjust] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionAdjust] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionAdjust] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
         //No Adjustment
         _conditionAdjustNone = {!(supportFire_adjustmentCoords isEqualTo [0,0])};
@@ -28,16 +25,10 @@
         };
         _actionAdjustNone = ["Remove Adjustment Direction","Remove Adjustment Direction","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjust.paa",_statementAdjustNone,_conditionAdjustNone] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjustNone] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjustNone] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Adjust Fire North
         _actionAdjust_N = ["Adjust North","Adjust North","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustN.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_N] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_N] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50N = {
                 supportFire_adjustmentCoords = [0, 50];
@@ -46,9 +37,6 @@
             };
             _actionAdjust_50N = ["Adjust North 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustN.paa",_statementAdjust_50N,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust North"], _actionAdjust_50N] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust North"], _actionAdjust_50N] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100N = {
                 supportFire_adjustmentCoords = [0, 100];
@@ -57,16 +45,10 @@
             };
             _actionAdjust_100N = ["Adjust North 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustN.paa",_statementAdjust_100N,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust North"], _actionAdjust_100N] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust North"], _actionAdjust_100N] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire Northeast
         _actionAdjust_NE = ["Adjust Northeast","Adjust Northeast","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNE.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_NE] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_NE] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50NE = {
                 supportFire_adjustmentCoords = [35.4, 35.4];
@@ -75,9 +57,6 @@
             };
             _actionAdjust_50NE = ["Adjust Northeast 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNE.paa",_statementAdjust_50NE,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Northeast"], _actionAdjust_50NE] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Northeast"], _actionAdjust_50NE] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100NE = {
                 supportFire_adjustmentCoords = [70.7, 70.7];
@@ -86,16 +65,10 @@
             };
             _actionAdjust_100NE = ["Adjust Northeast 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNE.paa",_statementAdjust_100NE,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Northeast"], _actionAdjust_100NE] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Northeast"], _actionAdjust_100NE] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire East
         _actionAdjust_E = ["Adjust East","Adjust East","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustE.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_E] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_E] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50E = {
                 supportFire_adjustmentCoords = [50, 0];
@@ -104,9 +77,6 @@
             };
             _actionAdjust_50E = ["Adjust East 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustE.paa",_statementAdjust_50E,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust East"], _actionAdjust_50E] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust East"], _actionAdjust_50E] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100E = {
                 supportFire_adjustmentCoords = [100, 0];
@@ -115,16 +85,10 @@
             };
             _actionAdjust_100E = ["Adjust East 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustE.paa",_statementAdjust_100E,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust East"], _actionAdjust_100E] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust East"], _actionAdjust_100E] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire Southeast
         _actionAdjust_SE = ["Adjust Southeast","Adjust Southeast","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSE.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_SE] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_SE] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50SE = {
                 supportFire_adjustmentCoords = [35.4, -35.4];
@@ -133,9 +97,6 @@
             };
             _actionAdjust_50E = ["Adjust Southeast 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSE.paa",_statementAdjust_50SE,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Southeast"], _actionAdjust_50E] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Southeast"], _actionAdjust_50E] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100SE = {
                 supportFire_adjustmentCoords = [70.7, -70.7];
@@ -144,16 +105,10 @@
             };
             _actionAdjust_100SE = ["Adjust Southeast 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSE.paa",_statementAdjust_100SE,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Southeast"], _actionAdjust_100SE] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Southeast"], _actionAdjust_100SE] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire South
         _actionAdjust_S = ["Adjust South","Adjust South","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustS.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_S] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_S] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50S = {
                 supportFire_adjustmentCoords = [0, -50];
@@ -162,9 +117,6 @@
             };
             _actionAdjust_50S = ["Adjust South 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustS.paa",_statementAdjust_50S,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust South"], _actionAdjust_50S] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust South"], _actionAdjust_50S] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100S = {
                 supportFire_adjustmentCoords = [0, -100];
@@ -173,16 +125,10 @@
             };
             _actionAdjust_100S = ["Adjust South 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustS.paa",_statementAdjust_100S,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust South"], _actionAdjust_100S] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust South"], _actionAdjust_100S] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire Southwest
         _actionAdjust_SW = ["Adjust Southwest","Adjust Southwest","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSW.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_SW] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_SW] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50SW = {
                 supportFire_adjustmentCoords = [-35.4, -35.4];
@@ -191,9 +137,6 @@
             };
             _actionAdjust_50SW = ["Adjust Southwest 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSW.paa",_statementAdjust_50SW,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Southwest"], _actionAdjust_50SW] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Southwest"], _actionAdjust_50SW] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100SW = {
                 supportFire_adjustmentCoords = [-70.7, -70.7];
@@ -202,16 +145,10 @@
             };
             _actionAdjust_100SW = ["Adjust Southwest 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustSW.paa",_statementAdjust_100SW,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Southwest"], _actionAdjust_100SW] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Southwest"], _actionAdjust_100SW] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire West
         _actionAdjust_W = ["Adjust West","Adjust West","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustW.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_W] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_W] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50W = {
                 supportFire_adjustmentCoords = [-50, 0];
@@ -220,9 +157,6 @@
             };
             _actionAdjust_50W = ["Adjust West 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustW.paa",_statementAdjust_50W,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust West"], _actionAdjust_50W] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust West"], _actionAdjust_50W] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100W = {
                 supportFire_adjustmentCoords = [-100, 0];
@@ -231,16 +165,10 @@
             };
             _actionAdjust_100W = ["Adjust West 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustW.paa",_statementAdjust_100W,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust West"], _actionAdjust_100W] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust West"], _actionAdjust_100W] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
         // Adjust Fire Northwest
         _actionAdjust_NW = ["Adjust Northwest","Adjust Northwest","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNW.paa",_statementAdjust,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire"], _actionAdjust_NW] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Adjust Fire"], _actionAdjust_NW] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
             _statementAdjust_50NW = {
                 supportFire_adjustmentCoords = [-35.4, 35.4];
@@ -249,9 +177,6 @@
             };
             _actionAdjust_50NW = ["Adjust Northwest 50","50m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNW.paa",_statementAdjust_50NW,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Northwest"], _actionAdjust_50NW] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Northwest"], _actionAdjust_50NW] call ace_interact_menu_fnc_addActionToZeus;
-            };
 
             _statementAdjust_100NW = {
                 supportFire_adjustmentCoords = [-70.7, 70.7];
@@ -260,6 +185,3 @@
             };
             _actionAdjust_100NW = ["Adjust Northwest 100","100m","Haas_WWII_Rebalance\UI\icon_supporting_fires_adjustNW.paa",_statementAdjust_100NW,{true}] call ace_interact_menu_fnc_createAction;
             [player, 1, ["ACE_SelfActions","Supporting Fires","Adjust Fire", "Adjust Northwest"], _actionAdjust_100NW] call ace_interact_menu_fnc_addActionToObject;
-            if (supportFire_isZEUS) then {
-                [["ACE_ZeusActions","Supporting Fires","Adjust Fire", "Adjust Northwest"], _actionAdjust_100NW] call ace_interact_menu_fnc_addActionToZeus;
-            };

--- a/missions/2PzD_Template.VR/modules/supporting_fires/actions/AmmoType.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/actions/AmmoType.sqf
@@ -5,16 +5,12 @@
     };
     _actionTarget01 = ["Ammunition Type","Ammunition Type","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementAmmoType,_conditionTargets] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionTarget01] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionTarget01] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
         // HE
         _conditionAmmoType_HE = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_shellsHE_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_shellsHE_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_shellsHE_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
         };
         _statementAmmoType_HE = {
             [["HE ammunition selected."],["Select the number of rounds to fire."], true] call CBA_fnc_notify;
@@ -22,16 +18,12 @@
         };
         _actionAmmoType_HE = ["HE","HE","Haas_WWII_Rebalance\UI\icon_supporting_fires_HE.paa",_statementAmmoType_HE,_conditionAmmoType_HE] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Ammunition Type"], _actionAmmoType_HE] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Ammunition Type"], _actionAmmoType_HE] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Smoke
         _conditionAmmoType_Smoke = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_shellsSmoke_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_shellsSmoke_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_shellsSmoke_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
         };
         _statementAmmoType_Smoke = {
             [["Smoke ammunition selected."],["Select the number of rounds to fire."], true] call CBA_fnc_notify;
@@ -39,16 +31,12 @@
         };
         _actionAmmoType_Smoke = ["Smoke","Smoke","Haas_WWII_Rebalance\UI\icon_supporting_fires_Smoke.paa",_statementAmmoType_Smoke,_conditionAmmoType_Smoke] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Ammunition Type"], _actionAmmoType_Smoke] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Ammunition Type"], _actionAmmoType_Smoke] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Flare
         _conditionAmmoType_Flare = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_shellsFlare_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_shellsFlare_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_shellsFlare_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS}}
         };
         _statementAmmoType_Flare = {
             [["Flare ammunition selected."],["Select the number of rounds to fire."], true] call CBA_fnc_notify;
@@ -56,6 +44,3 @@
         };
         _actionAmmoType_Flare = ["Flare","Flare","Haas_WWII_Rebalance\UI\icon_supporting_fires_flare.paa",_statementAmmoType_Flare,_conditionAmmoType_Flare] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Ammunition Type"], _actionAmmoType_Flare] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Ammunition Type"], _actionAmmoType_Flare] call ace_interact_menu_fnc_addActionToZeus;
-        };

--- a/missions/2PzD_Template.VR/modules/supporting_fires/actions/Targets.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/actions/Targets.sqf
@@ -5,9 +5,6 @@
     };
     _actionTargetsMain = ["Select Target","Select Target","Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTargetsMain,_conditionTargets] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionTargetsMain] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionTargetsMain] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     // ===== Add Targets
     if (supportFire_target01 != "") then {
@@ -17,9 +14,6 @@
         };
         _actionTarget01 = [supportFire_target01_Name,supportFire_target01_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget01,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget01] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget01] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
     if (supportFire_target02 != "") then {
         _statementTarget02 = {
@@ -28,9 +22,6 @@
         };
         _actionTarget02 = [supportFire_target02_Name,supportFire_target02_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget02,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget02] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget02] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
     if (supportFire_target03 != "") then {
         _statementTarget03 = {
@@ -39,9 +30,6 @@
         };
         _actionTarget03 = [supportFire_target03_Name,supportFire_target03_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget03,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget03] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget03] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
     if (supportFire_target04 != "") then {
         _statementTarget04 = {
@@ -50,9 +38,6 @@
         };
         _actionTarget04 = [supportFire_target04_Name,supportFire_target04_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget04,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget04] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget04] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
     if (supportFire_target05 != "") then {
         _statementTarget05 = {
@@ -61,9 +46,6 @@
         };
         _actionTarget05 = [supportFire_target05_Name,supportFire_target05_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget05,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget05] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget05] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
     if (supportFire_target06 != "") then {
         _statementTarget06 = {
@@ -72,17 +54,11 @@
         };
         _actionTarget06 = [supportFire_target06_Name,supportFire_target06_Name,"Haas_WWII_Rebalance\UI\icon_supporting_fires_target.paa",_statementTarget06,{true}] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionTarget06] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionTarget06] call ace_interact_menu_fnc_addActionToZeus;
-        };
     };
 
     _statementGrid = {createDialog "Supporting_Fires_Dialog";};
     _actionGrid = ["Grid","Grid","Haas_WWII_Rebalance\UI\icon_supporting_fires_target_grid.paa",_statementGrid,{true}] call ace_interact_menu_fnc_createAction; //TODO change to grid paa
     [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionGrid] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionGrid] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     _statementVisualLoc = {
         _supportFire_terrainPosition = screenToWorld [0.5,0.5];
@@ -109,9 +85,6 @@
     };
     _actionVisualLoc = ["Visual Location","Visual Location","Haas_WWII_Rebalance\UI\icon_supporting_fires_target_vis.paa",_statementVisualLoc,_conditionVisual] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionVisualLoc] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionVisualLoc] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
     _statementRepeat = {
         [[(format ["Target %1 will be repeated.<br/>Select adjustment if required, and the type of ammunition to use.",supportFire_previousTargetName])], true] call CBA_fnc_notify;
@@ -120,6 +93,3 @@
     };
     _actionRepeat = ["Repeat Last Target","Repeat Last Target","Haas_WWII_Rebalance\UI\icon_supporting_fires_target_rep.paa",_statementRepeat,_conditionRepeat] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires","Select Target"], _actionRepeat] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires","Select Target"], _actionRepeat] call ace_interact_menu_fnc_addActionToZeus;
-    };

--- a/missions/2PzD_Template.VR/modules/supporting_fires/actions/VolumeOfFire.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/actions/VolumeOfFire.sqf
@@ -5,16 +5,12 @@
     };
     _actionVolume = ["Volume of Fire","Volume of Fire","Haas_WWII_Rebalance\UI\icon_supporting_fires.paa",_statementVolume,_conditionTargets] call ace_interact_menu_fnc_createAction;
     [player, 1, ["ACE_SelfActions","Supporting Fires"], _actionVolume] call ace_interact_menu_fnc_addActionToObject;
-    if (supportFire_isZEUS) then {
-        [["ACE_ZeusActions","Supporting Fires"], _actionVolume] call ace_interact_menu_fnc_addActionToZeus;
-    };
 
         // 1 Round, HE
         _conditionVolumeHE1 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE1 = {
             [["1 round HE selected."], true] call CBA_fnc_notify;
@@ -22,16 +18,12 @@
         };
         _actionVolumeHE1 = ["HE - 1 Round","1 Round","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE1,_conditionVolumeHE1] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE1] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE1] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // 5 Rounds, HE
         _conditionVolumeHE5 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 4}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 4}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 4}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE5 = {
             [["5 rounds HE selected."], true] call CBA_fnc_notify;
@@ -39,16 +31,12 @@
         };
         _actionVolumeHE5 = ["HE - 5 Rounds","5 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE5,_conditionVolumeHE5] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE5] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE5] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // 10 Rounds, HE
         _conditionVolumeHE10 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 9}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 9}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 9}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE10 = {
             [["10 rounds HE selected."], true] call CBA_fnc_notify;
@@ -56,16 +44,12 @@
         };
         _actionVolumeHE10 = ["HE - 10 Rounds","10 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE10,_conditionVolumeHE10] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE10] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE10] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // 15 Rounds, HE
         _conditionVolumeHE15 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 14}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 14}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 14}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE15 = {
             [["15 rounds HE selected."], true] call CBA_fnc_notify;
@@ -73,16 +57,12 @@
         };
         _actionVolumeHE15 = ["HE - 15 Rounds","15 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE15,_conditionVolumeHE15] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE15] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE15] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // 20 Rounds, HE
         _conditionVolumeHE20 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 19}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 19}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 19}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE20 = {
             [["20 rounds HE selected."], true] call CBA_fnc_notify;
@@ -90,16 +70,12 @@
         };
         _actionVolumeHE20 = ["HE - 20 Rounds","20 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE20,_conditionVolumeHE20] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE20] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE20] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // 25 Rounds, HE
         _conditionVolumeHE25 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountWEST > 24}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountEAST > 24}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "HE"} && {supportFire_shellsHE_AmmoCountGUER > 24}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "HE"}}
         };
         _statementVolumeHE25 = {
             [["25 rounds HE selected."], true] call CBA_fnc_notify;
@@ -107,16 +83,12 @@
         };
         _actionVolumeHE25 = ["HE - 25 Rounds","25 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_he.paa",_statementVolumeHE25,_conditionVolumeHE25] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeHE25] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeHE25] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Target 01, 1 Round, Smoke
         _conditionVolumeSmoke1 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "Smoke"}}
         };
         _statementVolumeSmoke1 = {
             [["1 round smoke selected."], true] call CBA_fnc_notify;
@@ -124,16 +96,12 @@
         };
         _actionVolumeSmoke1 = ["Smoke - 1 Round","1 Round","Haas_WWII_Rebalance\UI\icon_supporting_fires_smoke.paa",_statementVolumeSmoke1,_conditionVolumeSmoke1] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke1] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke1] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Target 01, 5 Rounds, Smoke
         _conditionVolumeSmoke5 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountWEST > 4}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountEAST > 4}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountGUER > 4}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "Smoke"}}
         };
         _statementVolumeSmoke5 = {
             [["5 rounds smoke selected."], true] call CBA_fnc_notify;
@@ -141,16 +109,12 @@
         };
         _actionVolumeSmoke5 = ["Smoke - 5 Rounds","5 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_smoke.paa",_statementVolumeSmoke5,_conditionVolumeSmoke5] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke5] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke5] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Target 01, 10 Rounds, Smoke
         _conditionVolumeSmoke10 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountWEST > 9}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountEAST > 9}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "Smoke"} && {supportFire_shellsSmoke_AmmoCountGUER > 9}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "Smoke"}}
         };
         _statementVolumeSmoke10 = {
             [["10 rounds smoke selected."], true] call CBA_fnc_notify;
@@ -158,16 +122,12 @@
         };
         _actionVolumeSmoke10 = ["Smoke - 10 Rounds","10 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_smoke.paa",_statementVolumeSmoke10,_conditionVolumeSmoke10] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke10] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeSmoke10] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Target 01, 1 Round, Flare
         _conditionVolumeFlare1 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountWEST > 0}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountEAST > 0}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountGUER > 0}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "Flare"}}
         };
         _statementVolumeFlare1 = {
             [["1 round flare selected."], true] call CBA_fnc_notify;
@@ -175,16 +135,12 @@
         };
         _actionVolumeFlare1 = ["Flare - 1 Round","1 Round","Haas_WWII_Rebalance\UI\icon_supporting_fires_flare.paa",_statementVolumeFlare1,_conditionVolumeFlare1] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeFlare1] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeFlare1] call ace_interact_menu_fnc_addActionToZeus;
-        };
 
         // Target 01, 5 Rounds, Flare
         _conditionVolumeFlare5 = {
                 supportFire_isWEST && {supportFire_fireMissionAvailableWEST} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountWEST > 4}
             || {supportFire_isEAST && {supportFire_fireMissionAvailableEAST} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountEAST > 4}}
             || {supportFire_isGUER && {supportFire_fireMissionAvailableGUER} && {supportFire_ammoType isEqualTo "Flare"} && {supportFire_shellsFlare_AmmoCountGUER > 4}}
-            || {supportFire_isZEUS && {supportFire_fireMissionAvailableZEUS} && {supportFire_ammoType isEqualTo "Flare"}}
         };
         _statementVolumeFlare5 = {
             [["5 rounds flare selected."], true] call CBA_fnc_notify;
@@ -192,6 +148,3 @@
         };
         _actionVolumeFlare5 = ["Flare - 5 Rounds","5 Rounds","Haas_WWII_Rebalance\UI\icon_supporting_fires_flare.paa",_statementVolumeFlare5,_conditionVolumeFlare5] call ace_interact_menu_fnc_createAction;
         [player, 1, ["ACE_SelfActions","Supporting Fires","Volume of Fire"], _actionVolumeFlare5] call ace_interact_menu_fnc_addActionToObject;
-        if (supportFire_isZEUS) then {
-            [["ACE_ZeusActions","Supporting Fires","Volume of Fire"], _actionVolumeFlare5] call ace_interact_menu_fnc_addActionToZeus;
-        };

--- a/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_AmmoCheck.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_AmmoCheck.sqf
@@ -5,10 +5,6 @@ Olsen_FW_FNC_SupportFire_AmmoCheck = {
     // systemChat "ammo check started";
     // systemChat str supportFire_side;
 
-    if (supportFire_isZEUS) exitWith {
-        [["As Zeus you have unlimited rounds for all types."], true] call CBA_fnc_notify;
-    };
-
     if (supportFire_isWEST) then {
         // systemChat "west ammo counted";
         _supportFire_ammoCountHE = supportFire_shellsHE_AmmoCountWEST;

--- a/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_FireMission.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_FireMission.sqf
@@ -59,26 +59,17 @@ Olsen_FW_FNC_SupportFire_FireMission = {
         _supportFire_adjustDir = "";
     };
 
-    if (supportFire_isZEUS) then {
-        _supportFire_ammoLeft = 99;
-    } else {
-        _supportFire_ammoLeft = [_supportFire_type, _supportFire_number] call Olsen_FW_FNC_SupportFire_RemoveAmmo;
-        // systemChat ("_supportFire_ammoLeft - " + str _supportFire_ammoLeft);
+    _supportFire_ammoLeft = [_supportFire_type, _supportFire_number] call Olsen_FW_FNC_SupportFire_RemoveAmmo;
+    // systemChat ("_supportFire_ammoLeft - " + str _supportFire_ammoLeft);
 
-        // cancel if not enough ammo
-        if (_supportFire_ammoLeft < 0) exitWith {
-            // systemChat "Fire mission canceled";
-            [[(format ["Negative, not enough %1 rounds available.", _supportFire_type])], true] call CBA_fnc_notify;
-            [] call Olsen_FW_FNC_SupportFire_AmmoCheck;
-        };
+    // cancel if not enough ammo
+    if (_supportFire_ammoLeft < 0) exitWith {
+        // systemChat "Fire mission canceled";
+        [[(format ["Negative, not enough %1 rounds available.", _supportFire_type])], true] call CBA_fnc_notify;
+        [] call Olsen_FW_FNC_SupportFire_AmmoCheck;
     };
 
     // make fire missions unavailable for that side
-    if (supportFire_isZEUS) then {
-        supportFire_fireMissionAvailableZEUS = False;
-        publicVariable "supportFire_fireMissionAvailableZEUS";
-        // systemChat "Fire missions disabled";
-    };
     if (supportFire_isWEST) then {
         supportFire_fireMissionAvailableWEST = False;
         publicVariable "supportFire_fireMissionAvailableWEST";
@@ -135,26 +126,14 @@ Olsen_FW_FNC_SupportFire_FireMission = {
                 "_supportFire_grammar"
             ];
             
-            if (supportFire_isZEUS) exitWith {
-                [
-                    [(format ["Rounds complete on %1.", _supportFire_targetName])],
-                    true
-                ] call CBA_fnc_notify;
-            } else {
-                [
-                    [(format ["Rounds complete on %1.", _supportFire_targetName])],
-                    [(format ["%1 %2 %3 remaining.", _supportFire_ammoLeft, _supportFire_grammar, _supportFire_type])],
-                    true
-                ] call CBA_fnc_notify;
-            }:
+            [
+                [(format ["Rounds complete on %1.", _supportFire_targetName])],
+                [(format ["%1 %2 %3 remaining.", _supportFire_ammoLeft, _supportFire_grammar, _supportFire_type])],
+                true
+            ] call CBA_fnc_notify;
             // systemChat "Rounds complete";
 
             // make fire missions available again for the players side
-            if (supportFire_isZEUS) exitWith {
-                supportFire_fireMissionAvailableZEUS = True;
-                publicVariable "supportFire_fireMissionAvailableZEUS";
-                // systemChat "Fire missions disabled";
-            };
             if (supportFire_isWEST) exitWith {
                 supportFire_fireMissionAvailableWEST = True;
                 publicVariable "supportFire_fireMissionAvailableWEST";

--- a/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_GetTargetLocation.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/functions/FNC_SupportFire_GetTargetLocation.sqf
@@ -25,14 +25,6 @@ Olsen_FW_FNC_SupportFire_GetTargetLocation = {
 
         _supportFire_targetLoc = supportFire_previousTargetLoc;
 
-        if !(supportFire_isZEUS) then {
-            if (supportFire_repeatFireBonus < 1) then {supportFire_repeatFireBonus = 1};
-            supportFire_repeatFireBonus = supportFire_repeatFireBonus + 0.2;
-            if (supportFire_repeatFireBonus >= 3) then {supportFire_repeatFireBonus = 3};
-
-            supportFire_shellDispersion = supportFire_originalShellDispersion / supportFire_repeatFireBonus;
-            supportFire_shellAccuracy = supportFire_originalShellAccuracy / supportFire_repeatFireBonus;
-        };
         _supportFire_accuracy = supportFire_shellAccuracy;
 
         // systemChat ("supportFire_shellDispersion - " + str supportFire_shellDispersion);

--- a/missions/2PzD_Template.VR/modules/supporting_fires/init.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/init.sqf
@@ -111,17 +111,14 @@ if (isServer) then {
     publicVariable "supportFire_shellsFlare_AmmoCountEAST";
     publicVariable "supportFire_shellsFlare_AmmoCountGUER";
 
-    supportFire_fireMissionAvailableZEUS = True;
     supportFire_fireMissionAvailableWEST = True;
     supportFire_fireMissionAvailableEAST = True;
     supportFire_fireMissionAvailableGUER = True;
-    publicVariable "supportFire_fireMissionAvailableZEUS";
     publicVariable "supportFire_fireMissionAvailableWEST";
     publicVariable "supportFire_fireMissionAvailableEAST";
     publicVariable "supportFire_fireMissionAvailableGUER";
 };
 
-supportFire_isZEUS = false;
 supportFire_isWEST = false;
 supportFire_isEAST = false;
 supportFire_isGUER = false;
@@ -140,8 +137,6 @@ supportFire_target04_Name = "";
 supportFire_target05_Name = "";
 supportFire_target06_Name = "";
 
-if (supportFire_batterySizeZEUS < 1) then {supportFire_batterySizeZEUS = 1};
-if (supportFire_batterySizeZEUS > 25) then {supportFire_batterySizeZEUS = 25};
 if (supportFire_batterySizeWEST < 1) then {supportFire_batterySizeWEST = 1};
 if (supportFire_batterySizeWEST > 25) then {supportFire_batterySizeWEST = 25};
 if (supportFire_batterySizeEAST < 1) then {supportFire_batterySizeEAST = 1};
@@ -157,141 +152,107 @@ supportFire_volumeOfFire = 1;
 supportFire_adjustmentCoords = [0,0];
 supportFire_adjustmentDirection = "no adjustment";
 
-if (!isNil "God" && {God isEqualTo player || {group player isEqualTo group God}}) then {
-    supportFire_isZEUS = true;
-    supportFire_target01 = supportFire_target01ZEUS;
-    supportFire_target02 = supportFire_target02ZEUS;
-    supportFire_target03 = supportFire_target03ZEUS;
-    supportFire_target04 = supportFire_target04ZEUS;
-    supportFire_target05 = supportFire_target05ZEUS;
-    supportFire_target06 = supportFire_target06ZEUS;
+if (playerSide == WEST) exitWith {
+    supportFire_isWEST = true;
+    if (supportFire_shellsHE_AmmoCountWEST >= 1 || {supportFire_shellsSmoke_AmmoCountWEST >= 1} || {supportFire_shellsFlare_AmmoCountWEST >= 1}) then {
+        supportFire_target01 = supportFire_target01WEST;
+        supportFire_target02 = supportFire_target02WEST;
+        supportFire_target03 = supportFire_target03WEST;
+        supportFire_target04 = supportFire_target04WEST;
+        supportFire_target05 = supportFire_target05WEST;
+        supportFire_target06 = supportFire_target06WEST;
 
-    supportFire_target01_Name = markerText supportFire_target01ZEUS;
-    supportFire_target02_Name = markerText supportFire_target02ZEUS;
-    supportFire_target03_Name = markerText supportFire_target03ZEUS;
-    supportFire_target04_Name = markerText supportFire_target04ZEUS;
-    supportFire_target05_Name = markerText supportFire_target05ZEUS;
-    supportFire_target06_Name = markerText supportFire_target06ZEUS;
+        supportFire_target01_Name = markerText supportFire_target01WEST;
+        supportFire_target02_Name = markerText supportFire_target02WEST;
+        supportFire_target03_Name = markerText supportFire_target03WEST;
+        supportFire_target04_Name = markerText supportFire_target04WEST;
+        supportFire_target05_Name = markerText supportFire_target05WEST;
+        supportFire_target06_Name = markerText supportFire_target06WEST;
 
-    supportFire_shellsHE_Type = supportFire_shellsHE_TypeZEUS;
-    supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeZEUS;
-    supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeZEUS;
+        supportFire_shellsHE_Type = supportFire_shellsHE_TypeWEST;
+        supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeWEST;
+        supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeWEST;
 
-    supportFire_shellDispersion = supportFire_shellDispersionZEUS;
-    supportFire_shellAccuracy = 0;
+        supportFire_shellDispersion = supportFire_shellDispersionWEST;
+        supportFire_shellAccuracy = supportFire_shellAccuracyWEST;
 
-    supportFire_originalShellDispersion = supportFire_shellDispersionZEUS;
-    supportFire_originalShellAccuracy = 0;
+        supportFire_originalShellDispersion = supportFire_shellDispersionWEST;
+        supportFire_originalShellAccuracy = supportFire_shellAccuracyWEST;
 
-    supportFire_batterySize = 0;
+        supportFire_batterySize = supportFire_batterySizeWEST;
 
-    #include "actions.sqf"
+        #include "actions.sqf"
 
-    def_fireMissionBriefingMessage;
-} else {
-
-    if (playerSide == WEST) exitWith {
-        supportFire_isWEST = true;
-        if (supportFire_shellsHE_AmmoCountWEST >= 1 || {supportFire_shellsSmoke_AmmoCountWEST >= 1} || {supportFire_shellsFlare_AmmoCountWEST >= 1}) then {
-            supportFire_target01 = supportFire_target01WEST;
-            supportFire_target02 = supportFire_target02WEST;
-            supportFire_target03 = supportFire_target03WEST;
-            supportFire_target04 = supportFire_target04WEST;
-            supportFire_target05 = supportFire_target05WEST;
-            supportFire_target06 = supportFire_target06WEST;
-
-            supportFire_target01_Name = markerText supportFire_target01WEST;
-            supportFire_target02_Name = markerText supportFire_target02WEST;
-            supportFire_target03_Name = markerText supportFire_target03WEST;
-            supportFire_target04_Name = markerText supportFire_target04WEST;
-            supportFire_target05_Name = markerText supportFire_target05WEST;
-            supportFire_target06_Name = markerText supportFire_target06WEST;
-
-            supportFire_shellsHE_Type = supportFire_shellsHE_TypeWEST;
-            supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeWEST;
-            supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeWEST;
-
-            supportFire_shellDispersion = supportFire_shellDispersionWEST;
-            supportFire_shellAccuracy = supportFire_shellAccuracyWEST;
-
-            supportFire_originalShellDispersion = supportFire_shellDispersionWEST;
-            supportFire_originalShellAccuracy = supportFire_shellAccuracyWEST;
-
-            supportFire_batterySize = supportFire_batterySizeWEST;
-
-            #include "actions.sqf"
-
-            def_fireMissionBriefingMessage;
-        };
+        def_fireMissionBriefingMessage;
     };
+};
 
-    if (playerSide == EAST) exitWith {
-        supportFire_isEAST = true;
-        if (supportFire_shellsHE_AmmoCountEAST >= 1 || {supportFire_shellsSmoke_AmmoCountEAST >= 1} || {supportFire_shellsFlare_AmmoCountEAST >= 1}) then {
-            supportFire_target01 = supportFire_target01EAST;
-            supportFire_target02 = supportFire_target02EAST;
-            supportFire_target03 = supportFire_target03EAST;
-            supportFire_target04 = supportFire_target04EAST;
-            supportFire_target05 = supportFire_target05EAST;
-            supportFire_target06 = supportFire_target06EAST;
+if (playerSide == EAST) exitWith {
+    supportFire_isEAST = true;
+    if (supportFire_shellsHE_AmmoCountEAST >= 1 || {supportFire_shellsSmoke_AmmoCountEAST >= 1} || {supportFire_shellsFlare_AmmoCountEAST >= 1}) then {
+        supportFire_target01 = supportFire_target01EAST;
+        supportFire_target02 = supportFire_target02EAST;
+        supportFire_target03 = supportFire_target03EAST;
+        supportFire_target04 = supportFire_target04EAST;
+        supportFire_target05 = supportFire_target05EAST;
+        supportFire_target06 = supportFire_target06EAST;
 
-            supportFire_target01_Name = markerText supportFire_target01EAST;
-            supportFire_target02_Name = markerText supportFire_target02EAST;
-            supportFire_target03_Name = markerText supportFire_target03EAST;
-            supportFire_target04_Name = markerText supportFire_target04EAST;
-            supportFire_target05_Name = markerText supportFire_target05EAST;
-            supportFire_target06_Name = markerText supportFire_target06EAST;
+        supportFire_target01_Name = markerText supportFire_target01EAST;
+        supportFire_target02_Name = markerText supportFire_target02EAST;
+        supportFire_target03_Name = markerText supportFire_target03EAST;
+        supportFire_target04_Name = markerText supportFire_target04EAST;
+        supportFire_target05_Name = markerText supportFire_target05EAST;
+        supportFire_target06_Name = markerText supportFire_target06EAST;
 
-            supportFire_shellsHE_Type = supportFire_shellsHE_TypeEAST;
-            supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeEAST;
-            supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeEAST;
+        supportFire_shellsHE_Type = supportFire_shellsHE_TypeEAST;
+        supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeEAST;
+        supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeEAST;
 
-            supportFire_shellDispersion = supportFire_shellDispersionEAST;
-            supportFire_shellAccuracy = supportFire_shellAccuracyEAST;
+        supportFire_shellDispersion = supportFire_shellDispersionEAST;
+        supportFire_shellAccuracy = supportFire_shellAccuracyEAST;
 
-            supportFire_originalShellDispersion = supportFire_shellDispersionEAST;
-            supportFire_originalShellAccuracy = supportFire_shellAccuracyEAST;
+        supportFire_originalShellDispersion = supportFire_shellDispersionEAST;
+        supportFire_originalShellAccuracy = supportFire_shellAccuracyEAST;
 
-            supportFire_batterySize = supportFire_batterySizeEAST;
+        supportFire_batterySize = supportFire_batterySizeEAST;
 
-            #include "actions.sqf"
+        #include "actions.sqf"
 
-            def_fireMissionBriefingMessage;
-        };
+        def_fireMissionBriefingMessage;
     };
+};
 
-    if (playerSide == RESISTANCE) exitWith {
-        supportFire_isGUER = true;
-        if (supportFire_shellsHE_AmmoCountGUER >= 1 || {supportFire_shellsSmoke_AmmoCountGUER >= 1} || {supportFire_shellsFlare_AmmoCountGUER >= 1}) then {
-            supportFire_target01 = supportFire_target01GUER;
-            supportFire_target02 = supportFire_target02GUER;
-            supportFire_target03 = supportFire_target03GUER;
-            supportFire_target04 = supportFire_target04GUER;
-            supportFire_target05 = supportFire_target05GUER;
-            supportFire_target06 = supportFire_target06GUER;
+if (playerSide == RESISTANCE) exitWith {
+    supportFire_isGUER = true;
+    if (supportFire_shellsHE_AmmoCountGUER >= 1 || {supportFire_shellsSmoke_AmmoCountGUER >= 1} || {supportFire_shellsFlare_AmmoCountGUER >= 1}) then {
+        supportFire_target01 = supportFire_target01GUER;
+        supportFire_target02 = supportFire_target02GUER;
+        supportFire_target03 = supportFire_target03GUER;
+        supportFire_target04 = supportFire_target04GUER;
+        supportFire_target05 = supportFire_target05GUER;
+        supportFire_target06 = supportFire_target06GUER;
 
-            supportFire_target01_Name = markerText supportFire_target01GUER;
-            supportFire_target02_Name = markerText supportFire_target02GUER;
-            supportFire_target03_Name = markerText supportFire_target03GUER;
-            supportFire_target04_Name = markerText supportFire_target04GUER;
-            supportFire_target05_Name = markerText supportFire_target05GUER;
-            supportFire_target06_Name = markerText supportFire_target06GUER;
+        supportFire_target01_Name = markerText supportFire_target01GUER;
+        supportFire_target02_Name = markerText supportFire_target02GUER;
+        supportFire_target03_Name = markerText supportFire_target03GUER;
+        supportFire_target04_Name = markerText supportFire_target04GUER;
+        supportFire_target05_Name = markerText supportFire_target05GUER;
+        supportFire_target06_Name = markerText supportFire_target06GUER;
 
-            supportFire_shellsHE_Type = supportFire_shellsHE_TypeGUER;
-            supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeGUER;
-            supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeGUER;
+        supportFire_shellsHE_Type = supportFire_shellsHE_TypeGUER;
+        supportFire_shellsSmoke_Type = supportFire_shellsSmoke_TypeGUER;
+        supportFire_shellsFlare_Type = supportFire_shellsFlare_TypeGUER;
 
-            supportFire_shellDispersion = supportFire_shellDispersionGUER;
-            supportFire_shellAccuracy = supportFire_shellAccuracyGUER;
+        supportFire_shellDispersion = supportFire_shellDispersionGUER;
+        supportFire_shellAccuracy = supportFire_shellAccuracyGUER;
 
-            supportFire_originalShellDispersion = supportFire_shellDispersionGUER;
-            supportFire_originalShellAccuracy = supportFire_shellAccuracyGUER;
+        supportFire_originalShellDispersion = supportFire_shellDispersionGUER;
+        supportFire_originalShellAccuracy = supportFire_shellAccuracyGUER;
 
-            supportFire_batterySize = supportFire_batterySizeGUER;
+        supportFire_batterySize = supportFire_batterySizeGUER;
 
-            #include "actions.sqf"
+        #include "actions.sqf"
 
-            def_fireMissionBriefingMessage;
-        };
+        def_fireMissionBriefingMessage;
     };
 };

--- a/missions/2PzD_Template.VR/modules/supporting_fires/settings.sqf
+++ b/missions/2PzD_Template.VR/modules/supporting_fires/settings.sqf
@@ -43,14 +43,6 @@
     supportFire_target05GUER = "";
     supportFire_target06GUER = "";
 
-    // Zeus
-    supportFire_target01ZEUS = "";
-    supportFire_target02ZEUS = "";
-    supportFire_target03ZEUS = "";
-    supportFire_target04ZEUS = "";
-    supportFire_target05ZEUS = "";
-    supportFire_target06ZEUS = "";
-
 //TARGET NAMES
     // These are now automatically taken from the marker text set in the editor.
     // So make sure you name your markers appropriately.
@@ -63,7 +55,6 @@
     supportFire_batterySizeWEST = 5;
     supportFire_batterySizeEAST = 5;
     supportFire_batterySizeGUER = 5;
-    supportFire_batterySizeZEUS = 5;
 
 // AMMUNITION TYPE
     // There are three types of ammunition available, High Explosive, Smoke, and Flare.
@@ -95,20 +86,15 @@
     supportFire_shellsSmoke_TypeGUER = "Smoke_82mm_AMOS_White";
     supportFire_shellsFlare_TypeGUER = "LIB_40mm_White";
 
-    // ZEUS
-    supportFire_shellsHE_TypeZEUS = "Sh_82mm_AMOS";
-    supportFire_shellsSmoke_TypeZEUS = "Smoke_82mm_AMOS_White";
-    supportFire_shellsFlare_TypeZEUS = "LIB_40mm_White";
-
 // AMMUNITION AMOUNT
     // This allows you to set the amount of ammunition available to each side.
     // Note that HE and Smoke rounds are always fired in volleys of 5.
     // If fewer than 5 rounds are available for those types then no interaction for that ammo will show up.
 
     // WEST/Blufor
-    supportFire_shellsHE_AmmoCountWEST = 0;
-    supportFire_shellsSmoke_AmmoCountWEST = 0;
-    supportFire_shellsFlare_AmmoCountWEST = 0;
+    supportFire_shellsHE_AmmoCountWEST = 110;
+    supportFire_shellsSmoke_AmmoCountWEST = 110;
+    supportFire_shellsFlare_AmmoCountWEST = 110;
 
     // East/Opfor
     supportFire_shellsHE_AmmoCountEAST = 0;
@@ -120,12 +106,8 @@
     supportFire_shellsSmoke_AmmoCountGUER = 0;
     supportFire_shellsFlare_AmmoCountGUER = 0;
 
-    // Zeus
-    // Zeus has unlimited ammo
-
 // FIRE MISSION ACCURACY
     // Sets, per side, how close to the target the fire mission impact area be in metres, using RNG.
-    // Accuracy will always be perfect for Zeus
     // Higher number means less accurate.
     // 0 means the fire mission will always be centered directly on target.
     // 100 means the fire mission could be centered up to 100m away.
@@ -135,7 +117,6 @@
     supportFire_shellAccuracyWEST = 100;
     supportFire_shellAccuracyEAST = 100;
     supportFire_shellAccuracyGUER = 100;
-    // Zeus has perfect accuracy
 
 // FIRE MISSION DISPERSION
     // Sets, per side, the maximum distance (in metres) a shell can land from the centre of the impact area, using RNG.
@@ -150,4 +131,3 @@
     supportFire_shellDispersionWEST = 100;
     supportFire_shellDispersionEAST = 100;
     supportFire_shellDispersionGUER = 100;
-    supportFire_shellDispersionZEUS = 100;


### PR DESCRIPTION
Removes the Zeus option from the supporting fires module as it was never used and causes issues when the platoon commander is also logged in as admin (giving him Zeus). Being Zeus would give the platoon commander infinite ammo and perfect accuracy.

(I want to have it mentioned for the record, I DID fix the initial bug in the Zeus only code, but then decided to just axe the entire Zeus option from the module because of the above-mentioned issue. But I DID fix it!)

Closes #45 