### PR TITLE
Remove GEN_Flare from cold war vehicle loadout

### DIFF
--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutFIN.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutFIN.sqf
@@ -30,7 +30,7 @@
 Fin_Resupply = ["Fin_Resupply", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
     GEN_Medical;
@@ -43,7 +43,7 @@ Fin_Resupply = ["Fin_Resupply", {
 Fin_Squad = ["Fin_Squad", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
 
     Fin_Infantry_Supplies;
@@ -53,7 +53,7 @@ Fin_Squad = ["Fin_Squad", {
 Fin_Platoon = ["Fin_Platoon", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
 
@@ -64,7 +64,7 @@ Fin_Platoon = ["Fin_Platoon", {
 Fin_Tank = ["Fin_Tank", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Tank;
     

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutGEN.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutGEN.sqf
@@ -12,7 +12,7 @@
     [GEN_Gren_Smoke_R, 2] call Olsen_FW_FNC_AddItemVehicle; \
     [GEN_Gren_Smoke_Y, 2] call Olsen_FW_FNC_AddItemVehicle;
 
-#define GEN_Flare \
+#define GEN_Flare_WW2 \
     [GEN_Flare_Pistol, 1] call Olsen_FW_FNC_AddItemVehicle; \
     [GEN_Flare_W, 2] call Olsen_FW_FNC_AddItemVehicle; \
     [GEN_Flare_G, 2] call Olsen_FW_FNC_AddItemVehicle; \

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutNor.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutNor.sqf
@@ -20,7 +20,7 @@
 Nor_Resupply = ["Nor_Resupply", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
     GEN_Medical;
@@ -33,7 +33,7 @@ Nor_Resupply = ["Nor_Resupply", {
 Nor_Section = ["Nor_Section", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
 
     Nor_Infantry_Supplies;
@@ -43,7 +43,7 @@ Nor_Section = ["Nor_Section", {
 Nor_Platoon = ["Nor_Platoon", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
 

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutRUS.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutRUS.sqf
@@ -31,7 +31,7 @@
 Rus_Resupply = ["Rus_Resupply", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
     GEN_Medical;
@@ -44,7 +44,7 @@ Rus_Resupply = ["Rus_Resupply", {
 Rus_Squad = ["Rus_Squad", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
 
     Rus_Infantry_Supplies;
@@ -54,7 +54,7 @@ Rus_Squad = ["Rus_Squad", {
 Rus_Platoon = ["Rus_Platoon", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Medical;
 
@@ -65,7 +65,7 @@ Rus_Platoon = ["Rus_Platoon", {
 Rus_Tank = ["Rus_Tank", {
     params ["_vehicle"];
 
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Gren_Smoke;
     GEN_Tank;
     

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUK.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUK.sqf
@@ -32,7 +32,7 @@ UK_Resupply = ["UK_Resupply", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
     GEN_Medical;
 
@@ -45,7 +45,7 @@ UK_Section = ["UK_Section", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
 
     UK_Infantry_Supplies;
 
@@ -55,7 +55,7 @@ UK_Platoon = ["UK_Platoon", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
 
     UK_Infantry_Supplies;
@@ -66,7 +66,7 @@ UK_Tank = ["UK_Tank", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Tank;
 
     UK_Tank_Supplies;

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUKColdWar.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUKColdWar.sqf
@@ -59,7 +59,6 @@ UK85_Section = ["UK85_Section", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
 
     UK85_Infantry_Supplies;
 
@@ -69,7 +68,6 @@ UK85_Platoon = ["UK85_Platoon", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
 
     UK85_Infantry_Supplies;
 
@@ -90,7 +88,6 @@ UK85_Tank = ["UK85_Tank", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
     GEN_Tank;
 
     UK85_Tank_Supplies;

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUS.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUS.sqf
@@ -38,7 +38,7 @@ US_Resupply = ["US_Resupply", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
     GEN_Medical;
 
@@ -51,7 +51,7 @@ US_Squad = ["US_Squad", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
 
     US_Infantry_Supplies;
 
@@ -61,7 +61,7 @@ US_Platoon = ["US_Platoon", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
 
     US_Infantry_Supplies;
@@ -75,7 +75,7 @@ US_Tank_Early = ["US_Tank_Early", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Tank;
 
     US_Tank_Supplies;
@@ -88,7 +88,7 @@ US_Tank_Late = ["US_Tank_Late", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Tank;
 
     US_Tank_Supplies;

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutWHR.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutWHR.sqf
@@ -47,7 +47,7 @@ Ger_Resupply_Early = ["Ger_Resupply_Early", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
     GEN_Medical;
 
@@ -60,7 +60,7 @@ Ger_Gruppe_Early = ["Ger_Gruppe_Early", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
 
     Ger_Infantry_Supplies;
 
@@ -70,7 +70,7 @@ Ger_Zug_Early = ["Ger_Zug_Early", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
 
     Ger_Infantry_Supplies;
@@ -83,7 +83,7 @@ Ger_Resupply_Late = ["Ger_Resupply_Late", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
     GEN_Medical;
 
@@ -98,7 +98,7 @@ Ger_Gruppe_Late = ["Ger_Gruppe_Late", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
 
     Ger_Infantry_Supplies;
     Ger_Late_War_Supplies;
@@ -109,7 +109,7 @@ Ger_Zug_Late = ["Ger_Zug_Late", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Medical;
 
     Ger_Infantry_Supplies;
@@ -123,7 +123,7 @@ Ger_Panzer = ["Ger_Panzer", {
     params ["_vehicle"];
 
     GEN_Gren_Smoke;
-    GEN_Flare;
+    GEN_Flare_WW2;
     GEN_Tank;
 
     Ger_Panzer_Supplies;


### PR DESCRIPTION
GEN_Flare uses IFA flares and flare gun and can't be used in cold war. Renamed GEN_Flare to GEN_Flare_WW2 to make this clear for the future.

Closes #123 