### PR TITLE
Removes Finnish AT rifle

### DIFF
--- a/missions/2PzD_Template.VR/customization/geardefs/Finnish/gearDefFin.sqf
+++ b/missions/2PzD_Template.VR/customization/geardefs/Finnish/gearDefFin.sqf
@@ -32,9 +32,6 @@
 #define Fin_BP_HMG_Tripod						"NORTH_Maxim_Tripod_Bag"
 #define Fin_BP_HMG_Gun							"NORTH_Maxim_Gun_Bag"
 
-#define Fin_BP_AT_Tripod						"NORTH_Lahti_L39_Tripod_Bag"
-#define Fin_BP_AT_Gun							"NORTH_Lahti_L39_Gun_Bag"
-
 //Facewear 
 #define Fin_MedicalBand							"G_NORTH_FIN_Medicalarmband"
 #define Fin_Gloves							    "G_NORTH_FIN_Gloves"

--- a/missions/2PzD_Template.VR/customization/geardefs/Finnish/gearDefFinWeapons.sqf
+++ b/missions/2PzD_Template.VR/customization/geardefs/Finnish/gearDefFinWeapons.sqf
@@ -48,8 +48,6 @@
 
 #define Fin_Mag_Maxim_HMG					  "NORTH_200Rnd_762mm_Maxim_Inf"
 
-#define Fin_Mag_AT_Rifle					  "NORTH_10Rnd_20mm_L39_Inf"
-
 //Grenades
 #define Fin_Gren_Frag_M32					  "NORTH_M32Grenade_mag"
 #define Fin_Gren_Frag_M43					  "NORTH_M43Grenade_mag"

--- a/missions/2PzD_Template.VR/customization/loadouts/Finnish/loadoutFin39.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/Finnish/loadoutFin39.sqf
@@ -454,7 +454,7 @@
 
         [Fin_Uni_TL] call Olsen_FW_FNC_AddItem;
         [Fin_Vest_SMG] call Olsen_FW_FNC_AddItem;
-        [Fin_BP_AT_Tripod] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [Fin_Hat] call Olsen_FW_FNC_AddItemRandom;
         Fin_Face;
 
@@ -468,7 +468,7 @@
         //Extra
         [Fin_Gren_Frag_M32,1] call Olsen_FW_FNC_AddItem;
 		[Rus_Gren_Smoke,1] call Olsen_FW_FNC_AddItem;
-		[Fin_Mag_AT_Rifle,1,"vest"] call Olsen_FW_FNC_AddItem;
+		[Rus_Mag_PTRD,20,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Anti-Tank Rifle Gunner
@@ -476,8 +476,8 @@
         params ["_unit"];
 
         [Fin_Uni_r] call Olsen_FW_FNC_AddItemRandom;
-        [Fin_BP_AT_Gun] call Olsen_FW_FNC_AddItem;
-        [Fin_Helmet_Early_r] call Olsen_FW_FNC_AddItemRandom;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
+        [Fin_Helmet_Late_r] call Olsen_FW_FNC_AddItemRandom;
         Fin_Face;
 
         //Assigned Items
@@ -487,7 +487,8 @@
         F39_Weapon_Rifleman;
 
 		//Extra
-		[Fin_Mag_AT_Rifle,3,"vest"] call Olsen_FW_FNC_AddItem;
+		[Rus_Weap_PTRD,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_PTRD,20,"backpack"] call Olsen_FW_FNC_AddItem;
 		Remove_Helm_If_Needed;
     }];
 

--- a/missions/2PzD_Template.VR/customization/loadouts/Finnish/loadoutFin41.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/Finnish/loadoutFin41.sqf
@@ -442,7 +442,7 @@
 
         [Fin_Uni_TL] call Olsen_FW_FNC_AddItem;
         [Fin_Vest_SMG] call Olsen_FW_FNC_AddItem;
-        [Fin_BP_AT_Tripod] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [Fin_Hat] call Olsen_FW_FNC_AddItemRandom;
         Fin_Face;
 
@@ -456,7 +456,7 @@
         //Extra
         [Fin_Gren_Frag_M32,1] call Olsen_FW_FNC_AddItem;
 		[Rus_Gren_Smoke,1] call Olsen_FW_FNC_AddItem;
-		[Fin_Mag_AT_Rifle,1,"vest"] call Olsen_FW_FNC_AddItem;
+		[Rus_Mag_PTRD,20,"backpack"] call Olsen_FW_FNC_AddItem;
     }];
 
     //Anti-Tank Rifle Gunner
@@ -464,7 +464,7 @@
         params ["_unit"];
 
         [Fin_Uni_r] call Olsen_FW_FNC_AddItemRandom;
-        [Fin_BP_AT_Gun] call Olsen_FW_FNC_AddItem;
+        [Pol_BP_Batoh] call Olsen_FW_FNC_AddItem;
         [Fin_Helmet_Late_r] call Olsen_FW_FNC_AddItemRandom;
         Fin_Face;
 
@@ -475,7 +475,8 @@
         F41_Weapon_Rifleman;
 
 		//Extra
-		[Fin_Mag_AT_Rifle,3,"vest"] call Olsen_FW_FNC_AddItem;
+		[Rus_Weap_PTRD,1,"backpack"] call Olsen_FW_FNC_AddItem;
+        [Rus_Mag_PTRD,20,"backpack"] call Olsen_FW_FNC_AddItem;
 		Remove_Helm_If_Needed;
     }];
 

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutFIN.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutFIN.sqf
@@ -17,7 +17,7 @@
     [Fin_Mag_Suomi_S20, 10] call Olsen_FW_FNC_AddItemVehicle; \
     [Rus_Mag_SVT, 10] call Olsen_FW_FNC_AddItemVehicle; \
     [Fin_Gren_Frag_M32, 10] call Olsen_FW_FNC_AddItemVehicle; \
-    [Fin_Mag_AT_Rifle, 6] call Olsen_FW_FNC_AdditemVehicle; \
+    [Rus_Mag_PTRD, 30] call Olsen_FW_FNC_AdditemVehicle; \
     [GEN_Toolkit, 1] call Olsen_FW_FNC_AddItemVehicle;
 
 #define Fin_Tank_Supplies \


### PR DESCRIPTION
Replaces the Finnish AT rifle with the Russian PTRD and removes the Finnish AT rifle definitions.

The Finnish AT rifle proved too gimmicky to use properly in-game and wasn't effective at all.

Closes #120 