### PR TITLE
Lr radio change

### DIFF
--- a/compositions/!2PzD_UK_85/composition.sqe
+++ b/compositions/!2PzD_UK_85/composition.sqe
@@ -1,5 +1,5 @@
 version=54;
-center[]={1423.0022,5,1483.2493};
+center[]={6097.9438,5,3257.0317};
 class items
 {
 	items=7;
@@ -15,7 +15,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.002197,0.0014390945,4.8007813};
+					position[]={-11.000488,0.0014390945,4.8024902};
 					angles[]={0,1.6190023,0};
 				};
 				side="West";
@@ -111,7 +111,7 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim";
 					};
 				};
-				id=47229;
+				id=1;
 				type="cwr3_b_uk_officer";
 				class CustomAttributes
 				{
@@ -161,7 +161,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.002197,0.0014390945,2.8007813};
+					position[]={-11.000488,0.0014390945,2.8024902};
 					angles[]={0,1.5693477,0};
 				};
 				side="West";
@@ -173,7 +173,7 @@ class items
 					description="Platoon Sergeant@1 Platoon | HQ Section";
 					isPlayable=1;
 				};
-				id=47235;
+				id=2;
 				type="cwr3_b_uk_soldier_tl";
 				class CustomAttributes
 				{
@@ -223,7 +223,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.002197,0.0014390945,2.8007813};
+					position[]={-13.000977,0.0014390945,2.8022461};
 					angles[]={0,1.5712501,0};
 				};
 				side="West";
@@ -322,11 +322,30 @@ class items
 						headgear="cwr3_b_uk_headgear_beret_infantry";
 					};
 				};
-				id=47250;
+				id=3;
 				type="cwr3_b_uk_soldier_medic";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=2;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -345,7 +364,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -364,7 +383,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item3
@@ -372,7 +391,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.002197,0.0014390945,4.8007813};
+					position[]={-13.000977,0.0014390945,4.8022461};
 					angles[]={0,1.5712501,0};
 				};
 				side="West";
@@ -471,11 +490,30 @@ class items
 						headgear="cwr3_b_uk_headgear_beret_infantry";
 					};
 				};
-				id=47251;
+				id=4;
 				type="cwr3_b_uk_soldier_medic";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=2;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -494,7 +532,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -513,14 +551,14 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 		};
 		class Attributes
 		{
 		};
-		id=47228;
+		id=0;
 	};
 	class Item1
 	{
@@ -534,7 +572,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,-3.1992188};
+					position[]={0.99951172,0.0014390945,-3.1975098};
 					angles[]={0,4.6645145,0};
 				};
 				side="West";
@@ -642,7 +680,7 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim";
 					};
 				};
-				id=47415;
+				id=6;
 				type="cwr3_b_uk_soldier_sl";
 				class CustomAttributes
 				{
@@ -692,7 +730,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0157471,0.0014390945,-3.2111816};
+					position[]={3.0175781,0.0014390945,-3.2094727};
 					angles[]={0,4.7232623,0};
 				};
 				side="West";
@@ -703,7 +741,7 @@ class items
 					description="AT Rifleman (L14A1)@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47416;
+				id=7;
 				type="cwr3_b_uk_soldier_at_carlgustaf";
 				class CustomAttributes
 				{
@@ -753,7 +791,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,-3.1992188};
+					position[]={4.9995117,0.0014390945,-3.1975098};
 					angles[]={0,4.7210636,0};
 				};
 				side="West";
@@ -764,7 +802,7 @@ class items
 					description="AT Rifleman Asst.@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47417;
+				id=8;
 				type="cwr3_b_uk_soldier_aat_carlgustaf";
 				class CustomAttributes
 				{
@@ -814,7 +852,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,-3.1992188};
+					position[]={6.9995117,0.0014390945,-3.1975098};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -825,7 +863,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47418;
+				id=9;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -875,7 +913,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,-3.1992188};
+					position[]={8.9990234,0.0014390945,-3.1977539};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -954,11 +992,30 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim_camo";
 					};
 				};
-				id=47419;
+				id=10;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -977,7 +1034,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -996,7 +1053,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -1004,7 +1061,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,-3.1992188};
+					position[]={10.999512,0.0014390945,-3.1975098};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -1015,7 +1072,7 @@ class items
 					description="Rifleman@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47420;
+				id=11;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -1065,7 +1122,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,-5.1992188};
+					position[]={0.99951172,0.0014390945,-5.1975098};
 					angles[]={0,4.7129645,0};
 				};
 				side="West";
@@ -1077,7 +1134,7 @@ class items
 					description="Team Leader@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47421;
+				id=12;
 				type="cwr3_b_uk_soldier_tl";
 				class CustomAttributes
 				{
@@ -1127,7 +1184,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.9978027,0.0014390945,-5.1992188};
+					position[]={2.9995117,0.0014390945,-5.1975098};
 					angles[]={0,4.7131572,0};
 				};
 				side="West";
@@ -1138,7 +1195,7 @@ class items
 					description="Machinegunner@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47422;
+				id=13;
 				type="cwr3_b_uk_soldier_mg";
 				class CustomAttributes
 				{
@@ -1188,7 +1245,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,-5.1992188};
+					position[]={4.9995117,0.0014390945,-5.1975098};
 					angles[]={0,4.7143259,0};
 				};
 				side="West";
@@ -1199,7 +1256,7 @@ class items
 					description="Machinegunner Asst.@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47423;
+				id=14;
 				type="cwr3_b_uk_soldier_amg";
 				class CustomAttributes
 				{
@@ -1249,7 +1306,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,-5.1992188};
+					position[]={6.9995117,0.0014390945,-5.1975098};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -1260,7 +1317,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47424;
+				id=15;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -1310,7 +1367,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,-5.1992188};
+					position[]={10.999512,0.0014390945,-5.1975098};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -1321,7 +1378,7 @@ class items
 					description="Rifleman@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47425;
+				id=16;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -1371,7 +1428,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,-5.1992188};
+					position[]={8.9995117,0.0014390945,-5.1975098};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -1382,7 +1439,7 @@ class items
 					description="Rifleman@1 Platoon | 1 Section";
 					isPlayable=1;
 				};
-				id=47426;
+				id=17;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -1431,7 +1488,7 @@ class items
 		class Attributes
 		{
 		};
-		id=47414;
+		id=5;
 	};
 	class Item2
 	{
@@ -1445,7 +1502,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,4.8007813};
+					position[]={0.99951172,0.0014390945,4.8024902};
 					angles[]={0,4.6645145,0};
 				};
 				side="West";
@@ -1553,7 +1610,7 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim";
 					};
 				};
-				id=47441;
+				id=19;
 				type="cwr3_b_uk_soldier_sl";
 				class CustomAttributes
 				{
@@ -1603,7 +1660,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0157471,0.0014390945,4.7888184};
+					position[]={3.0175781,0.0014390945,4.7905273};
 					angles[]={0,4.7232623,0};
 				};
 				side="West";
@@ -1614,7 +1671,7 @@ class items
 					description="AT Rifleman (L14A1)@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47442;
+				id=20;
 				type="cwr3_b_uk_soldier_at_carlgustaf";
 				class CustomAttributes
 				{
@@ -1664,7 +1721,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,4.8007813};
+					position[]={4.9995117,0.0014390945,4.8024902};
 					angles[]={0,4.7210636,0};
 				};
 				side="West";
@@ -1675,7 +1732,7 @@ class items
 					description="AT Rifleman Asst.@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47443;
+				id=21;
 				type="cwr3_b_uk_soldier_aat_carlgustaf";
 				class CustomAttributes
 				{
@@ -1725,7 +1782,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,4.8007813};
+					position[]={6.9995117,0.0014390945,4.8024902};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -1736,7 +1793,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47444;
+				id=22;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -1786,7 +1843,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,4.8007813};
+					position[]={8.9990234,0.0014390945,4.8022461};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -1865,11 +1922,30 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim_camo";
 					};
 				};
-				id=47445;
+				id=23;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -1888,7 +1964,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -1907,7 +1983,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -1915,7 +1991,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,4.8007813};
+					position[]={10.999512,0.0014390945,4.8024902};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -1926,7 +2002,7 @@ class items
 					description="Rifleman@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47446;
+				id=24;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -1976,7 +2052,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,2.8007813};
+					position[]={0.99951172,0.0014390945,2.8024902};
 					angles[]={0,4.7129645,0};
 				};
 				side="West";
@@ -1988,7 +2064,7 @@ class items
 					description="Team Leader@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47447;
+				id=25;
 				type="cwr3_b_uk_soldier_tl";
 				class CustomAttributes
 				{
@@ -2038,7 +2114,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.9978027,0.0014390945,2.8007813};
+					position[]={2.9995117,0.0014390945,2.8024902};
 					angles[]={0,4.7131572,0};
 				};
 				side="West";
@@ -2049,7 +2125,7 @@ class items
 					description="Machinegunner@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47448;
+				id=26;
 				type="cwr3_b_uk_soldier_mg";
 				class CustomAttributes
 				{
@@ -2099,7 +2175,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,2.8007813};
+					position[]={4.9995117,0.0014390945,2.8024902};
 					angles[]={0,4.7143259,0};
 				};
 				side="West";
@@ -2110,7 +2186,7 @@ class items
 					description="Machinegunner Asst.@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47449;
+				id=27;
 				type="cwr3_b_uk_soldier_amg";
 				class CustomAttributes
 				{
@@ -2160,7 +2236,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,2.8007813};
+					position[]={6.9995117,0.0014390945,2.8024902};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -2171,7 +2247,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47450;
+				id=28;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -2221,7 +2297,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,2.8007813};
+					position[]={10.999512,0.0014390945,2.8024902};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -2232,7 +2308,7 @@ class items
 					description="Rifleman@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47451;
+				id=29;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -2282,7 +2358,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,2.8007813};
+					position[]={8.9995117,0.0014390945,2.8024902};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -2293,7 +2369,7 @@ class items
 					description="Rifleman@1 Platoon | 2 Section";
 					isPlayable=1;
 				};
-				id=47452;
+				id=30;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -2342,7 +2418,7 @@ class items
 		class Attributes
 		{
 		};
-		id=47440;
+		id=18;
 	};
 	class Item3
 	{
@@ -2356,7 +2432,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,12.800781};
+					position[]={0.99951172,0.0014390945,12.80249};
 					angles[]={0,4.6645145,0};
 				};
 				side="West";
@@ -2464,7 +2540,7 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim";
 					};
 				};
-				id=47481;
+				id=32;
 				type="cwr3_b_uk_soldier_sl";
 				class CustomAttributes
 				{
@@ -2514,7 +2590,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={3.0157471,0.0014390945,12.788818};
+					position[]={3.0175781,0.0014390945,12.790527};
 					angles[]={0,4.7232623,0};
 				};
 				side="West";
@@ -2525,7 +2601,7 @@ class items
 					description="AT Rifleman (L14A1)@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47482;
+				id=33;
 				type="cwr3_b_uk_soldier_at_carlgustaf";
 				class CustomAttributes
 				{
@@ -2575,7 +2651,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,12.800781};
+					position[]={4.9995117,0.0014390945,12.80249};
 					angles[]={0,4.7210636,0};
 				};
 				side="West";
@@ -2586,7 +2662,7 @@ class items
 					description="AT Rifleman Asst.@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47483;
+				id=34;
 				type="cwr3_b_uk_soldier_aat_carlgustaf";
 				class CustomAttributes
 				{
@@ -2636,7 +2712,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,12.800781};
+					position[]={6.9995117,0.0014390945,12.80249};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -2647,7 +2723,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47484;
+				id=35;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -2697,7 +2773,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,12.800781};
+					position[]={8.9990234,0.0014390945,12.802246};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -2776,11 +2852,30 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim_camo";
 					};
 				};
-				id=47485;
+				id=36;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -2799,7 +2894,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -2818,7 +2913,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -2826,7 +2921,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,12.800781};
+					position[]={10.999512,0.0014390945,12.80249};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -2837,7 +2932,7 @@ class items
 					description="Rifleman@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47486;
+				id=37;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -2887,7 +2982,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={0.99780273,0.0014390945,10.800781};
+					position[]={0.99951172,0.0014390945,10.80249};
 					angles[]={0,4.7129645,0};
 				};
 				side="West";
@@ -2899,7 +2994,7 @@ class items
 					description="Team Leader@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47487;
+				id=38;
 				type="cwr3_b_uk_soldier_tl";
 				class CustomAttributes
 				{
@@ -2949,7 +3044,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={2.9978027,0.0014390945,10.800781};
+					position[]={2.9995117,0.0014390945,10.80249};
 					angles[]={0,4.7131572,0};
 				};
 				side="West";
@@ -2960,7 +3055,7 @@ class items
 					description="Machinegunner@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47488;
+				id=39;
 				type="cwr3_b_uk_soldier_mg";
 				class CustomAttributes
 				{
@@ -3010,7 +3105,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={4.9978027,0.0014390945,10.800781};
+					position[]={4.9995117,0.0014390945,10.80249};
 					angles[]={0,4.7143259,0};
 				};
 				side="West";
@@ -3021,7 +3116,7 @@ class items
 					description="Machinegunner Asst.@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47489;
+				id=40;
 				type="cwr3_b_uk_soldier_amg";
 				class CustomAttributes
 				{
@@ -3071,7 +3166,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={6.9978027,0.0014390945,10.800781};
+					position[]={6.9995117,0.0014390945,10.80249};
 					angles[]={-0,4.7183928,0};
 				};
 				side="West";
@@ -3082,7 +3177,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47490;
+				id=41;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -3132,7 +3227,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={10.997803,0.0014390945,10.800781};
+					position[]={10.999512,0.0014390945,10.80249};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -3143,7 +3238,7 @@ class items
 					description="Rifleman@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47491;
+				id=42;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -3193,7 +3288,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={8.9978027,0.0014390945,10.800781};
+					position[]={8.9995117,0.0014390945,10.80249};
 					angles[]={0,4.7168741,0};
 				};
 				side="West";
@@ -3204,7 +3299,7 @@ class items
 					description="Rifleman@1 Platoon | 3 Section";
 					isPlayable=1;
 				};
-				id=47492;
+				id=43;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -3253,7 +3348,7 @@ class items
 		class Attributes
 		{
 		};
-		id=47480;
+		id=31;
 	};
 	class Item4
 	{
@@ -3267,7 +3362,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.002197,0.0014390945,-3.1992188};
+					position[]={-11.000488,0.0014390945,-3.1975098};
 					angles[]={0,1.5712153,0};
 				};
 				side="West";
@@ -3279,7 +3374,7 @@ class items
 					description="Recon Team Leader@1 Platoon | Recon Team";
 					isPlayable=1;
 				};
-				id=47494;
+				id=45;
 				type="cwr3_b_uk_soldier_spotter";
 				class CustomAttributes
 				{
@@ -3329,7 +3424,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.002197,0.0014390945,-3.1992188};
+					position[]={-13.000488,0.0014390945,-3.1975098};
 					angles[]={0,1.5624362,0};
 				};
 				side="West";
@@ -3340,7 +3435,7 @@ class items
 					description="Recon Team Sniper@1 Platoon | Recon Team";
 					isPlayable=1;
 				};
-				id=47495;
+				id=46;
 				type="cwr3_b_uk_soldier_sniper";
 				class CustomAttributes
 				{
@@ -3389,7 +3484,7 @@ class items
 		class Attributes
 		{
 		};
-		id=47493;
+		id=44;
 	};
 	class Item5
 	{
@@ -3403,7 +3498,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-11.002197,0.0014390945,11.800781};
+					position[]={-11.000488,0.0014390945,11.80249};
 					angles[]={0,1.5769747,0};
 				};
 				side="West";
@@ -3415,7 +3510,7 @@ class items
 					description="Tank Commander@Tank Crew";
 					isPlayable=1;
 				};
-				id=47501;
+				id=48;
 				type="cwr3_b_uk_soldier_crewman";
 				class CustomAttributes
 				{
@@ -3465,7 +3560,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.002197,0.0014390945,10.800781};
+					position[]={-13.000488,0.0014390945,10.80249};
 					angles[]={0,1.5769747,0};
 				};
 				side="West";
@@ -3476,7 +3571,7 @@ class items
 					description="Tank Crewman@Tank Crew";
 					isPlayable=1;
 				};
-				id=47502;
+				id=49;
 				type="cwr3_b_uk_soldier_crewman";
 				class CustomAttributes
 				{
@@ -3526,7 +3621,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-13.002197,0.0014390945,12.800781};
+					position[]={-13.000488,0.0014390945,12.80249};
 					angles[]={0,1.5769747,0};
 				};
 				side="West";
@@ -3537,7 +3632,7 @@ class items
 					description="Tank Crewman@Tank Crew";
 					isPlayable=1;
 				};
-				id=47503;
+				id=50;
 				type="cwr3_b_uk_soldier_crewman";
 				class CustomAttributes
 				{
@@ -3586,7 +3681,7 @@ class items
 		class Attributes
 		{
 		};
-		id=47500;
+		id=47;
 	};
 	class Item6
 	{
@@ -3600,7 +3695,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0021973,0.0014390945,-11.199219};
+					position[]={-5.0004883,0.0014390945,-11.19751};
 					angles[]={0,6.2337399,0};
 				};
 				side="West";
@@ -3708,7 +3803,7 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim";
 					};
 				};
-				id=47505;
+				id=52;
 				type="cwr3_b_uk_soldier_sl";
 				class CustomAttributes
 				{
@@ -3758,7 +3853,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-5.0112305,0.0014390945,-13.217163};
+					position[]={-5.0092773,0.0014390945,-13.215576};
 					angles[]={0,0.0093026049,0};
 				};
 				side="West";
@@ -3769,7 +3864,7 @@ class items
 					description="AT Rifleman (L14A1)@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47506;
+				id=53;
 				type="cwr3_b_uk_soldier_at_carlgustaf";
 				class CustomAttributes
 				{
@@ -3819,7 +3914,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9962158,0.0014390945,-15.199219};
+					position[]={-4.9941406,0.0014390945,-15.19751};
 					angles[]={0,0.0071034902,0};
 				};
 				side="West";
@@ -3830,7 +3925,7 @@ class items
 					description="AT Rifleman Asst.@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47507;
+				id=54;
 				type="cwr3_b_uk_soldier_aat_carlgustaf";
 				class CustomAttributes
 				{
@@ -3880,8 +3975,8 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9921875,0.0014390945,-17.199219};
-					angles[]={0,0.0044331364,0};
+					position[]={-4.9902344,0.0014390945,-17.19751};
+					angles[]={-0,0.0044331364,0};
 				};
 				side="West";
 				flags=4;
@@ -3891,7 +3986,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47508;
+				id=55;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -3941,8 +4036,8 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9902344,0.0014390945,-19.199219};
-					angles[]={0,0.0044331364,0};
+					position[]={-4.987793,0.0014390945,-19.197754};
+					angles[]={-0,0.0044331364,0};
 				};
 				side="West";
 				flags=4;
@@ -4020,11 +4115,30 @@ class items
 						headgear="cwr3_b_uk_headgear_mk5_helmet_scrim_camo";
 					};
 				};
-				id=47509;
+				id=56;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
 					class Attribute0
+					{
+						property="ace_isMedic";
+						expression="if (_value != -1 && {_value != (parseNumber (_this getUnitTrait 'medic'))}) then {_this setVariable [""ace_medical_medicClass"", _value, true]}";
+						class Value
+						{
+							class data
+							{
+								class type
+								{
+									type[]=
+									{
+										"SCALAR"
+									};
+								};
+								value=1;
+							};
+						};
+					};
+					class Attribute1
 					{
 						property="speaker";
 						expression="_this setspeaker _value;";
@@ -4043,7 +4157,7 @@ class items
 							};
 						};
 					};
-					class Attribute1
+					class Attribute2
 					{
 						property="pitch";
 						expression="_this setpitch _value;";
@@ -4062,7 +4176,7 @@ class items
 							};
 						};
 					};
-					nAttributes=2;
+					nAttributes=3;
 				};
 			};
 			class Item5
@@ -4070,7 +4184,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-4.9862061,0.0014390945,-21.199219};
+					position[]={-4.984375,0.0014390945,-21.19751};
 					angles[]={0,0.0029146997,0};
 				};
 				side="West";
@@ -4081,7 +4195,7 @@ class items
 					description="Rifleman@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47510;
+				id=57;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -4131,7 +4245,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-7.0021973,0.0014390945,-11.202271};
+					position[]={-7.0004883,0.0014390945,-11.200684};
 					angles[]={0,6.2821903,0};
 				};
 				side="West";
@@ -4143,7 +4257,7 @@ class items
 					description="Team Leader@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47511;
+				id=58;
 				type="cwr3_b_uk_soldier_tl";
 				class CustomAttributes
 				{
@@ -4193,7 +4307,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.9991455,0.0014390945,-13.202271};
+					position[]={-6.9970703,0.0014390945,-13.200684};
 					angles[]={0,6.2823825,0};
 				};
 				side="West";
@@ -4204,7 +4318,7 @@ class items
 					description="Machinegunner@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47512;
+				id=59;
 				type="cwr3_b_uk_soldier_mg";
 				class CustomAttributes
 				{
@@ -4254,7 +4368,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.9962158,0.0014390945,-15.202271};
+					position[]={-6.9941406,0.0014390945,-15.200684};
 					angles[]={0,0.00036651915,0};
 				};
 				side="West";
@@ -4265,7 +4379,7 @@ class items
 					description="Machinegunner Asst.@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47513;
+				id=60;
 				type="cwr3_b_uk_soldier_amg";
 				class CustomAttributes
 				{
@@ -4315,8 +4429,8 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.9921875,0.0014390945,-17.202271};
-					angles[]={0,0.0044331364,0};
+					position[]={-6.9902344,0.0014390945,-17.200439};
+					angles[]={-0,0.0044331364,0};
 				};
 				side="West";
 				flags=4;
@@ -4326,7 +4440,7 @@ class items
 					description="Rifleman (M72A3)@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47514;
+				id=61;
 				type="cwr3_b_uk_soldier_at_law";
 				class CustomAttributes
 				{
@@ -4376,7 +4490,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.9862061,0.0014390945,-21.202271};
+					position[]={-6.984375,0.0014390945,-21.200439};
 					angles[]={0,0.0029146997,0};
 				};
 				side="West";
@@ -4387,7 +4501,7 @@ class items
 					description="Rifleman@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47515;
+				id=62;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -4437,7 +4551,7 @@ class items
 				dataType="Object";
 				class PositionInfo
 				{
-					position[]={-6.9902344,0.0014390945,-19.202271};
+					position[]={-6.9882813,0.0014390945,-19.200439};
 					angles[]={0,0.0029146997,0};
 				};
 				side="West";
@@ -4448,7 +4562,7 @@ class items
 					description="Rifleman@1 Platoon | Reserve Section";
 					isPlayable=1;
 				};
-				id=47516;
+				id=63;
 				type="cwr3_b_uk_soldier";
 				class CustomAttributes
 				{
@@ -4497,6 +4611,6 @@ class items
 		class Attributes
 		{
 		};
-		id=47504;
+		id=51;
 	};
 };

--- a/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCW.sqf
+++ b/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCW.sqf
@@ -16,7 +16,7 @@
 //Backpack
 #define UKCW_BP							"cwr3_b_uk_backpack"
 #define UKCW_BP_Medic					"cwr3_b_uk_backpack_medic_empty"
-#define UKCW_BP_Radio					"cwr3_b_backpack_radio"
+#define UKCW_BP_Radio					"cwr3_b_backpack_radio" // DO NOT USE THIS DIRECTLY. USE THE UKCW_Radio_LR defined below!
 
 //Headgear
 #define UKCW_Helm						"cwr3_b_uk_headgear_mk5_helmet_scrim"
@@ -26,6 +26,13 @@
 #define UKCW_Beret_Tank					"cwr3_b_uk_headgear_beret_headset_tank"
 
 //Misc
+#define UKCW_Radio_PRC117F              "ACRE_PRC117F"
+#define UKCW_CargoSling                 "slr_slingload_CargoSling"
+
+#define UKCW_Radio_LR \
+    [UKCW_BP_Radio] call Olsen_FW_FNC_AddItemRandom; \
+    clearAllItemsFromBackpack _unit; \
+    _unit addItemToBackpack UKCW_Radio_PRC117F;
 #define UK_Leader_Equipment_Set \
     [GEN_Bino] call Olsen_FW_FNC_AddItem; \
     [GEN_ace_maptools,1,"uniform"] call Olsen_FW_FNC_AddItem;

--- a/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCW.sqf
+++ b/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCW.sqf
@@ -31,7 +31,6 @@
 
 #define UKCW_Radio_LR \
     [UKCW_BP_Radio] call Olsen_FW_FNC_AddItemRandom; \
-    clearAllItemsFromBackpack _unit; \
     _unit addItemToBackpack UKCW_Radio_PRC117F;
 #define UK_Leader_Equipment_Set \
     [GEN_Bino] call Olsen_FW_FNC_AddItem; \

--- a/missions/2PzD_Template.VR/customization/loadouts/British_ColdWar/loadoutUK85.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/British_ColdWar/loadoutUK85.sqf
@@ -71,7 +71,7 @@
 		[UKCW_Uni] call Olsen_FW_FNC_AddItem;
 		[UKCW_Vest_Officer] call Olsen_FW_FNC_AddItem;
 		[UKCW_Helm_r] call Olsen_FW_FNC_AddItemRandom;
-		[UKCW_BP_Radio] call Olsen_FW_FNC_AddItemRandom;
+		UKCW_Radio_LR;
 
         //Assigned Items
         GEN_Default_Equipment_Set;
@@ -120,6 +120,7 @@
         //Assigned Items
         GEN_Default_Equipment_Set;
         GEN_MedicP_Equipment_Set;
+        UK_Leader_Equipment_Set;
 
         //Primary Weapon
         UK85_L2A3;

--- a/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUKColdWar.sqf
+++ b/missions/2PzD_Template.VR/customization/loadoutsVeh/vehLoadoutUKColdWar.sqf
@@ -44,6 +44,8 @@
 UK85_Resupply = ["UK85_Resupply", {
     params ["_vehicle"];
 
+    [UKCW_CargoSling, 2] call Olsen_FW_FNC_AddItemVehicle;
+
     GEN_Gren_Smoke;
     GEN_Medical;
     GEN_Medical;


### PR DESCRIPTION
- Changed the LR radio of the PL to the same one that the helicopters and other CW vehicles use as the old one couldn't connect to those. Note that the PL still spawns with the old radio as well, because the commands to remove that don't work in MP. He'll have to manually remove it from his inventory.
- Changed platoon medics to be doctors and squad medics to be field medics, in line with intended changes to the medical system to use medical vehicles.
- Added cargo sling objects to the UK85 resupply vehicles to use with helicopters.
- Gave the UK85 medic some binos because "we get bored and we like to look at the action".