### PR TITLE
Changed sniper rifle for UK85 Recon team

### DIFF
--- a/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCWWeapons.sqf
+++ b/missions/2PzD_Template.VR/customization/geardefs/British_ColdWar/gearDefUKCWWeapons.sqf
@@ -5,6 +5,7 @@
 #define UKCW_Weap_L2A3					"cwr3_smg_sterling"
 #define UKCW_Weap_L7A2					"CUP_lmg_L7A2" // GPMG
 #define UKCW_Weap_L42A1					"cwr3_srifle_l42a1_no23" // Sniper
+#define UKCW_Weap_M21					"CUP_srifle_M21" // Sniper (has tracer ammo available)
 
 //Ammo
 #define UKCW_Mag_L1A1_20Rnd				"CUP_20Rnd_762x51_FNFAL_M"
@@ -13,6 +14,8 @@
 #define UKCW_Mag_L2A3_30Rnd				"cwr3_30rnd_sterling_m"
 #define UKCW_Mag_L7A2_100Rnd_Red		"CUP_100Rnd_TE4_LRT4_Red_Tracer_762x51_Belt_M"
 #define UKCW_Mag_L41A1					"CUP_5Rnd_762x51_M24"
+#define UKCW_Mag_M21					"CUP_20Rnd_762x51_DMR"
+#define UKCW_Mag_M21_Red				"CUP_20Rnd_TE1_Red_Tracer_762x51_DMR"
 
 #define UKCW_Mag_CG_HEAT				"cwr3_carlgustaf_heat_m"
 #define UKCW_Mag_CG_HEDP				"cwr3_carlgustaf_hedp_m"
@@ -26,3 +29,6 @@
 #define UKCW_Weap_CarlGustaf			"cwr3_launch_carlgustaf" // Reloadable AT
 #define UKCW_Weap_M72A3					"cwr3_launch_m72a3" // Single use AT
 #define UKCW_Weap_Javelin				"cwr3_launch_javelin" // AA
+
+//Attachments
+#define UKCW_Acc_M21_Scope				"CUP_optic_artel_m14"

--- a/missions/2PzD_Template.VR/customization/loadouts/British_ColdWar/loadoutUK85.sqf
+++ b/missions/2PzD_Template.VR/customization/loadouts/British_ColdWar/loadoutUK85.sqf
@@ -55,10 +55,12 @@
         [UKCW_Mag_CG_HEAT, 1, "backpack"] call Olsen_FW_FNC_AddItem; \
         [UKCW_Mag_CG_HEDP, 1, "backpack"] call Olsen_FW_FNC_AddItem;
 
-#define UK85_L42A1 \
-        [UKCW_Mag_L41A1, 1] call Olsen_FW_FNC_AddItem; \
-		[UKCW_Weap_L42A1] call Olsen_FW_FNC_AddItem; \
-		[UKCW_Mag_L41A1, 20, "vest"] call Olsen_FW_FNC_AddItem;
+#define UK85_M21 \
+        [UKCW_Mag_M21, 1] call Olsen_FW_FNC_AddItem; \
+		[UKCW_Weap_M21] call Olsen_FW_FNC_AddItem; \
+        [UKCW_Acc_M21_Scope, 1] call Olsen_FW_FNC_AddItem; \
+		[UKCW_Mag_M21, 5, "vest"] call Olsen_FW_FNC_AddItem; \
+        [UKCW_Mag_M21_Red, 5, "vest"] call Olsen_FW_FNC_AddItem;
 
 //======================== Loadouts ========================
 
@@ -352,7 +354,7 @@
         GEN_Default_Equipment_Set;
 
         //Primary Weapon
-        UK85_L42A1;
+        UK85_M21;
 
         //Extra
         [UKCW_Gren_Frag,1] call Olsen_FW_FNC_AddItem;


### PR DESCRIPTION
The L42A1 does not have access to any tracer ammunition. The M21 does, hence the change.

Closes #133 